### PR TITLE
Add searchable school directory for Masuda

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -257,44 +257,242 @@ img {
   color: var(--muted);
 }
 
-.tabs {
-  display: inline-flex;
-  border-radius: 999px;
+.school-search {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 36px;
+  align-items: start;
+}
+
+.filters {
+  background: var(--card);
+  padding: 28px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 24px;
+  position: sticky;
+  top: 96px;
+}
+
+.search-box label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.search-box input[type='search'] {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
-  padding: 6px;
-  background: rgba(255, 255, 255, 0.7);
-  margin: 0 auto 40px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-box input[type='search']:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(0, 167, 216, 0.18);
+}
+
+.help-text {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.type-filter {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 16px 18px;
+  display: grid;
+  gap: 12px;
+  background: rgba(47, 77, 228, 0.04);
+}
+
+.type-filter legend {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.type-filter label {
   display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+}
+
+.type-filter input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+
+.tag-filter {
+  display: grid;
+  gap: 16px;
+}
+
+.tag-filter-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.clear-tags {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tag-chip {
+  border: 1px solid rgba(47, 77, 228, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: rgba(47, 77, 228, 0.08);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.tag-chip:hover,
+.tag-chip:focus {
+  transform: translateY(-2px);
+}
+
+.tag-chip.active {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 16px 32px rgba(47, 77, 228, 0.18);
+}
+
+.results {
+  display: grid;
+  gap: 24px;
+}
+
+.result-summary {
+  background: rgba(47, 77, 228, 0.06);
+  border-radius: var(--radius-md);
+  padding: 20px 24px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.result-summary strong {
+  font-size: 1.25rem;
+  margin-right: 6px;
+}
+
+.result-breakdown {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.school-list {
+  display: grid;
+  gap: 20px;
+}
+
+.school-card {
+  background: var(--card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+  padding: 28px;
+  display: grid;
+  gap: 16px;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.school-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 36px 64px rgba(15, 35, 95, 0.12);
+  border-color: rgba(47, 77, 228, 0.18);
+}
+
+.school-card header {
+  display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 
-.tab-panels {
-  display: grid;
-  gap: 28px;
+.school-type {
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
 }
 
-.tab-panels .card-grid {
-  display: none;
-}
-
-.tab-panels .card-grid.active {
-  display: grid;
-}
-
-.tab {
-  padding: 10px 22px;
-  border: none;
-  background: transparent;
-  border-radius: 999px;
+.school-area {
+  margin: 0;
   font-weight: 600;
   color: var(--muted);
-  cursor: pointer;
 }
 
-.tab.active {
-  background: var(--primary);
-  color: #fff;
-  box-shadow: 0 8px 16px rgba(47, 77, 228, 0.18);
+.school-detail {
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.school-detail div {
+  display: grid;
+  gap: 4px;
+}
+
+.school-detail dt {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.school-detail dd {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.school-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.school-tags li {
+  background: rgba(47, 77, 228, 0.08);
+  color: var(--primary);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.empty-state {
+  margin: 0;
+  padding: 28px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(47, 77, 228, 0.4);
+  color: var(--muted);
+  text-align: center;
+  font-weight: 500;
 }
 
 .card-grid {
@@ -572,6 +770,14 @@ img {
   .hero-card {
     order: -1;
   }
+
+  .school-search {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    position: static;
+  }
 }
 
 @media (max-width: 640px) {
@@ -585,6 +791,28 @@ img {
 
   .support-wrapper,
   .contact-form {
+    padding: 24px;
+  }
+
+  .filters {
+    padding: 22px;
+    gap: 20px;
+  }
+
+  .type-filter {
+    padding: 14px 16px;
+  }
+
+  .tag-chip {
+    font-size: 0.8rem;
+    padding: 6px 12px;
+  }
+
+  .result-summary {
+    padding: 16px 18px;
+  }
+
+  .school-card {
     padding: 24px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -71,136 +71,42 @@
       <div class="container">
         <div class="section-heading">
           <h2>学校別で探す</h2>
-          <p>益田市内の学校と連携した習い事・部活動支援プログラムをご紹介。</p>
+          <p>島根県益田市内の小・中・高を一覧化。学校種とタグで横断検索できます。</p>
         </div>
-        <div class="tabs" role="tablist" aria-label="学校カテゴリ">
-          <button class="tab active" role="tab" id="tab-elementary" aria-selected="true" aria-controls="panel-elementary" data-target="elementary">小学校</button>
-          <button class="tab" role="tab" id="tab-middle" aria-selected="false" aria-controls="panel-middle" data-target="middle">中学校</button>
-          <button class="tab" role="tab" id="tab-high" aria-selected="false" aria-controls="panel-high" data-target="high">高校</button>
-        </div>
-        <div class="tab-panels">
-          <div class="card-grid active" role="tabpanel" id="panel-elementary" aria-labelledby="tab-elementary" data-panel="elementary">
-            <article class="card">
-              <header>
-                <p class="category">吉田小学校エリア</p>
-                <h3>まなびの森サイエンスクラブ</h3>
-              </header>
-              <p>理科好きが集まる探究クラブ。ドローンプログラミングや水質調査など、地域フィールドワークと合わせて体験。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 小学3〜6年生</li>
-                <li><strong>開催:</strong> 毎週土曜日 / 13:30-15:30</li>
-                <li><strong>場所:</strong> 益田市立市民学習センター</li>
-              </ul>
-              <span class="more" aria-label="詳しくは吉田小学校エリアの教室にお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">益田小学校エリア</p>
-                <h3>MASUDA アフタースクール英語ラボ</h3>
-              </header>
-              <p>英語で遊びながら学べるコミュニケーション重視のクラス。ALT経験者が益田市内の児童に合わせた教材で指導します。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 小学1〜6年生</li>
-                <li><strong>開催:</strong> 月・水曜日 / 16:00-18:00</li>
-                <li><strong>場所:</strong> 益田市駅前町 MASUDA HUB 教室</li>
-              </ul>
-              <span class="more" aria-label="詳しくはMASUDA アフタースクール英語ラボまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">鎌手小学校エリア</p>
-                <h3>石見海辺のSTEAMクラブ</h3>
-              </header>
-              <p>日本海の自然を活用した理科・アート融合プログラム。海洋観察とデジタル制作を組み合わせて学びを深めます。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 小学4〜6年生</li>
-                <li><strong>開催:</strong> 隔週土曜日 / 10:00-12:00</li>
-                <li><strong>場所:</strong> 益田市鎌手町 海辺の学習拠点</li>
-              </ul>
-              <span class="more" aria-label="詳しくは石見海辺のSTEAMクラブまでお問い合わせください">詳細は各教室へ</span>
-            </article>
+        <div class="school-search" aria-label="益田市内の学校検索">
+          <div class="filters" role="region" aria-label="検索条件">
+            <div class="search-box">
+              <label for="school-search-input">学校名・キーワード検索</label>
+              <input id="school-search-input" type="search" placeholder="例: 益田小学校 / 中山間地域 / 私立" autocomplete="off">
+              <p class="help-text">学校名・所在地・特徴・タグで横断検索できます。</p>
+            </div>
+            <fieldset class="type-filter">
+              <legend>学校種で絞り込む</legend>
+              <label>
+                <input type="checkbox" name="school-type" value="elementary" checked>
+                <span>小学校</span>
+              </label>
+              <label>
+                <input type="checkbox" name="school-type" value="middle" checked>
+                <span>中学校</span>
+              </label>
+              <label>
+                <input type="checkbox" name="school-type" value="high" checked>
+                <span>高校</span>
+              </label>
+            </fieldset>
+            <div class="tag-filter" role="region" aria-label="タグで絞り込む">
+              <div class="tag-filter-heading">
+                <span>タグ</span>
+                <button type="button" class="clear-tags" id="clear-tag-filter" hidden>選択中のタグをクリア</button>
+              </div>
+              <div class="tag-list" id="tag-list" role="listbox" aria-multiselectable="true"></div>
+              <p class="help-text">タグをクリックすると複数選択できます。</p>
+            </div>
           </div>
-          <div class="card-grid" role="tabpanel" id="panel-middle" aria-labelledby="tab-middle" data-panel="middle" hidden>
-            <article class="card">
-              <header>
-                <p class="category">益田東中学校エリア</p>
-                <h3>益田ユナイテッド バスケットボールクラブ</h3>
-              </header>
-              <p>全国大会出場経験のあるコーチ陣が直接指導。個々のスキルアップとチームワーク強化に特化したプログラム。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 中学1〜3年生</li>
-                <li><strong>開催:</strong> 火・木・日曜日</li>
-                <li><strong>場所:</strong> 益田市民体育館</li>
-              </ul>
-              <span class="more" aria-label="詳しくは益田ユナイテッド バスケットボールクラブまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">横田中学校エリア</p>
-                <h3>石見リサーチ探究ラボ</h3>
-              </header>
-              <p>島根県立大学と連携した探究型学習。益田市内の地域課題をテーマにフィールドワークとデータ分析を行います。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 中学1〜3年生</li>
-                <li><strong>開催:</strong> 隔週土曜日 / 13:00-16:00</li>
-                <li><strong>場所:</strong> 益田市高津町 県立大学サテライト</li>
-              </ul>
-              <span class="more" aria-label="詳しくは石見リサーチ探究ラボまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">匹見中学校エリア</p>
-                <h3>匹見アドベンチャーアカデミー</h3>
-              </header>
-              <p>山里に広がる益田市匹見町で行う自然体験プログラム。リバートレッキングや木工クラフトで自己表現力を育みます。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 中学1〜3年生</li>
-                <li><strong>開催:</strong> 月1回 / 9:30-15:30</li>
-                <li><strong>場所:</strong> 益田市匹見町 学びの里みちくさ</li>
-              </ul>
-              <span class="more" aria-label="詳しくは匹見アドベンチャーアカデミーまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-          </div>
-          <div class="card-grid" role="tabpanel" id="panel-high" aria-labelledby="tab-high" data-panel="high" hidden>
-            <article class="card">
-              <header>
-                <p class="category">益田翔陽高校エリア</p>
-                <h3>グローカル探究ゼミ</h3>
-              </header>
-              <p>地域企業と連携した課題解決型ゼミ。ビジネスアイデア創出やプレゼンテーションの基礎を実践的に学ぶことができます。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 高校1〜3年生</li>
-                <li><strong>開催:</strong> 隔週土曜日 / 10:00-16:00</li>
-                <li><strong>場所:</strong> 益田市役所 コミュニティホール</li>
-              </ul>
-              <span class="more" aria-label="詳しくはグローカル探究ゼミまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">益田東高校エリア</p>
-                <h3>益田クリエイティブスタジオ</h3>
-              </header>
-              <p>映像制作やグラフィックデザインを実践的に学ぶラボ。地域の企業案件を取り上げ、リアルな制作体験ができます。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 高校1〜3年生</li>
-                <li><strong>開催:</strong> 毎週金曜日 / 17:30-19:30</li>
-                <li><strong>場所:</strong> 益田市駅前町 MASUDA HUB クリエイティブルーム</li>
-              </ul>
-              <span class="more" aria-label="詳しくは益田クリエイティブスタジオまでお問い合わせください">詳細は各教室へ</span>
-            </article>
-            <article class="card">
-              <header>
-                <p class="category">吉賀高校連携</p>
-                <h3>石見起業チャレンジプログラム</h3>
-              </header>
-              <p>益田市と吉賀町の高校生が協働する起業体験講座。地域資源を活かしたビジネスプランづくりを専門家が伴走支援します。</p>
-              <ul class="meta">
-                <li><strong>対象:</strong> 高校1〜3年生</li>
-                <li><strong>開催:</strong> 全6回 / 土曜日集中</li>
-                <li><strong>場所:</strong> 益田市駅前町 シェアオフィスPORTO</li>
-              </ul>
-              <span class="more" aria-label="詳しくは石見起業チャレンジプログラムまでお問い合わせください">詳細は各教室へ</span>
-            </article>
+          <div class="results" role="region" aria-live="polite" aria-busy="false">
+            <div class="result-summary" id="result-summary"></div>
+            <div class="school-list" id="school-list" role="list"></div>
           </div>
         </div>
       </div>
@@ -259,7 +165,7 @@
               <p class="category">ウェルネス</p>
               <h3>石見ヨガスタジオ 夜クラス</h3>
             </header>
-            <p>呼吸と瞑想を取り入たリラックスプログラム。初心者でも安心して参加できる少人数制。</p>
+            <p>呼吸と瞑想を取り入れたリラックスプログラム。初心者でも安心して参加できる少人数制。</p>
             <ul class="meta">
               <li><strong>期間:</strong> 隔週水曜日 / 19:00-20:30</li>
               <li><strong>会場:</strong> 益田駅前スタジオ</li>
@@ -312,26 +218,394 @@
     <p class="copyright">&copy; 2024 MASUDA Learning Hub</p>
   </footer>
   <script>
-    const tabs = document.querySelectorAll('.tabs .tab');
-    const panels = document.querySelectorAll('.tab-panels [data-panel]');
+    const SCHOOLS = [
+      {
+        name: '益田市立益田小学校',
+        type: 'elementary',
+        area: '益田市元町エリア',
+        address: '益田市元町6-30',
+        tags: ['公立', '小学校', '市街地', 'ICT活用', '放課後子ども教室', 'コミュニティ・スクール'],
+        notes: '市街地中心部にある大規模校。タブレット学習や英語専科など先進的な授業を進め、地域ボランティアと連携したキャリア教育も盛んです。',
+        programs: '地域の読み聞かせボランティアや放課後クラブと連携した学びを展開。'
+      },
+      {
+        name: '益田市立吉田小学校',
+        type: 'elementary',
+        area: '益田市乙吉町エリア',
+        address: '益田市乙吉町イ114',
+        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '自然体験'],
+        notes: '吉田川沿いの住宅地に位置し、地域行事と連動した学びが特徴。校内農園を活用した食育に取り組んでいます。'
+      },
+      {
+        name: '益田市立中西小学校',
+        type: 'elementary',
+        area: '益田市中吉田町エリア',
+        address: '益田市中吉田町37',
+        tags: ['公立', '小学校', '市街地', '小規模校', 'コミュニティ・スクール'],
+        notes: '少人数ならではのきめ細かなサポートが魅力。地域企業と連携したキャリア体験学習を継続的に実施しています。'
+      },
+      {
+        name: '益田市立高津小学校',
+        type: 'elementary',
+        area: '益田市高津町エリア',
+        address: '益田市高津町イ2320',
+        tags: ['公立', '小学校', '沿岸部', 'コミュニティ・スクール', 'スポーツ'],
+        notes: '日本海に近い高津地区の拠点校。水辺の環境を生かした総合学習や海洋教育、少年スポーツが盛んな学校です。'
+      },
+      {
+        name: '益田市立飯田小学校',
+        type: 'elementary',
+        area: '益田市飯田町エリア',
+        address: '益田市飯田町21-2',
+        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '国際交流'],
+        notes: '益田駅に近い立地。国際理解教育やALTとの交流、読書活動が充実しており、地域図書館との連携も進んでいます。'
+      },
+      {
+        name: '益田市立西益田小学校',
+        type: 'elementary',
+        area: '益田市乙吉町エリア',
+        address: '益田市乙吉町イ331-3',
+        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '児童クラブ'],
+        notes: '住宅地が広がる西益田地区の中核校。地域と協働した防災学習や児童クラブを併設し、安全・安心の体制を整えています。'
+      },
+      {
+        name: '益田市立東仙道小学校',
+        type: 'elementary',
+        area: '益田市東町エリア',
+        address: '益田市東町12-6',
+        tags: ['公立', '小学校', '市街地', '文化財学習', 'コミュニティ・スクール'],
+        notes: '歴史ある寺社が多い東仙道地区の伝統校。石見神楽など地域文化を生かした総合学習が特色です。'
+      },
+      {
+        name: '益田市立横田小学校',
+        type: 'elementary',
+        area: '益田市高津町横田エリア',
+        address: '益田市高津町イ2955',
+        tags: ['公立', '小学校', '市街地', '小規模校', '自然体験'],
+        notes: '周囲を田園が囲む横田地区の学校。里山を活用した自然体験や複式学級による丁寧な指導が魅力です。'
+      },
+      {
+        name: '益田市立二条小学校',
+        type: 'elementary',
+        area: '益田市二条町エリア',
+        address: '益田市二条町イ127',
+        tags: ['公立', '小学校', '中山間地域', '小規模校', 'スクールバス'],
+        notes: '匹見川上流に近い中山間地域の学校。スクールバス運行や地域行事と連動した学習が盛んです。'
+      },
+      {
+        name: '益田市立七尾小学校',
+        type: 'elementary',
+        area: '益田市七尾町エリア',
+        address: '益田市七尾町8',
+        tags: ['公立', '小学校', '沿岸部', '小規模校', '自然体験'],
+        notes: '海と山に囲まれた七尾町の学校。海洋体験や森林体験を通じたふるさと教育を実践しています。'
+      },
+      {
+        name: '益田市立鎌手小学校',
+        type: 'elementary',
+        area: '益田市鎌手町エリア',
+        address: '益田市鎌手町ロ77-3',
+        tags: ['公立', '小学校', '沿岸部', 'コミュニティ・スクール', 'スクールバス'],
+        notes: '日本海沿いの漁業地域に位置。神楽学習や海の安全教室など地域密着の学びが魅力です。'
+      },
+      {
+        name: '益田市立匹見小学校',
+        type: 'elementary',
+        area: '益田市匹見町エリア',
+        address: '益田市匹見町匹見イ982',
+        tags: ['公立', '小学校', '山間地域', '小規模校', 'スクールバス', 'コミュニティ・スクール'],
+        notes: '中国山地の豊かな自然に囲まれた小規模校。森林環境教育や地域人材による体験学習が充実しています。',
+        programs: '山村留学制度「匹見Rise」など全国からの受け入れ実績があります。'
+      },
+      {
+        name: '益田市立美都小学校',
+        type: 'elementary',
+        area: '益田市美都町エリア',
+        address: '益田市美都町都茂1186',
+        tags: ['公立', '小学校', '山間地域', '小規模校', 'コミュニティ・スクール'],
+        notes: '旧美都町の中心部にある小学校。茶摘みや郷土芸能など地域資源を活かした学習を展開しています。'
+      },
+      {
+        name: '益田市立都茂小学校',
+        type: 'elementary',
+        area: '益田市美都町都茂エリア',
+        address: '益田市美都町都茂1523',
+        tags: ['公立', '小学校', '山間地域', '小規模校', 'スクールバス'],
+        notes: '山間地にある複式学級の学校。森づくり学習や地域との協働による体験活動が特色です。'
+      },
+      {
+        name: '益田市立益田中学校',
+        type: 'middle',
+        area: '益田市染羽町エリア',
+        address: '益田市染羽町1-5',
+        tags: ['公立', '中学校', '市街地', '部活動充実', '探究学習'],
+        notes: '市中心部の総合校。部活動数が多く、地域と連動した総合的な探究学習を推進しています。'
+      },
+      {
+        name: '益田市立高津中学校',
+        type: 'middle',
+        area: '益田市高津町エリア',
+        address: '益田市高津町イ2360',
+        tags: ['公立', '中学校', '沿岸部', '部活動充実', 'キャリア教育'],
+        notes: '高津地区の拠点中学校。キャリア教育や地域企業との連携授業を展開し、海洋教育も取り入れています。'
+      },
+      {
+        name: '益田市立横田中学校',
+        type: 'middle',
+        area: '益田市高津町横田エリア',
+        address: '益田市高津町イ2745',
+        tags: ['公立', '中学校', '市街地', '小規模校', '地域連携'],
+        notes: '小規模ながら地域密着型の学校。小中連携による英語強化や農業体験が特徴です。'
+      },
+      {
+        name: '益田市立匹見中学校',
+        type: 'middle',
+        area: '益田市匹見町エリア',
+        address: '益田市匹見町匹見イ1104',
+        tags: ['公立', '中学校', '山間地域', '小規模校', '寮・下宿対応', 'スクールバス'],
+        notes: '中国山地の自然の中で学ぶ中学校。遠距離通学を支える下宿制度や山村留学を受け入れています。',
+        programs: '森林環境学習やカヌー体験など、アウトドアプログラムが豊富です。'
+      },
+      {
+        name: '益田市立美都中学校',
+        type: 'middle',
+        area: '益田市美都町エリア',
+        address: '益田市美都町都茂1186-2',
+        tags: ['公立', '中学校', '山間地域', '小規模校', 'コミュニティ・スクール'],
+        notes: '地域ぐるみで学びを支えるコミュニティ・スクール。茶どころ美都の文化を活かしたふるさと学習を行っています。'
+      },
+      {
+        name: '益田東中学校',
+        type: 'middle',
+        area: '益田市久城町エリア',
+        address: '益田市久城町457',
+        tags: ['私立', '中学校', '市街地', '中高一貫', '探究学習', '部活動充実'],
+        notes: '益田東高等学校と連携した中高一貫校。難関大学進学を見据えた探究型学習と強化指定クラブが充実しています。'
+      },
+      {
+        name: '島根県立益田高等学校',
+        type: 'high',
+        area: '益田市東町エリア',
+        address: '益田市東町20-33',
+        tags: ['公立', '高校', '全日制', '普通科', '進学校', '探究学習', '部活動充実'],
+        notes: '県内屈指の進学校。理数探究類型や地域探究プロジェクトを推進し、全国規模の学びの機会が豊富です。'
+      },
+      {
+        name: '島根県立益田翔陽高等学校',
+        type: 'high',
+        area: '益田市昭和町エリア',
+        address: '益田市昭和町12-1',
+        tags: ['公立', '高校', '全日制', '専門学科', 'キャリア教育', '部活動充実'],
+        notes: '普通科に加え産業系・福祉系など多彩な学科を設置。地域企業と連動した実習や資格取得支援が手厚い学校です。'
+      },
+      {
+        name: '益田東高等学校',
+        type: 'high',
+        area: '益田市久城町エリア',
+        address: '益田市久城町457',
+        tags: ['私立', '高校', '全日制', '中高一貫', '進学コース', '部活動強化'],
+        notes: '中高一貫の私立校。特別進学・グローバルなど複数コースを設置し、寮完備で全国から生徒を受け入れています。'
+      },
+      {
+        name: '明誠高等学校',
+        type: 'high',
+        area: '益田市三宅町エリア',
+        address: '益田市三宅町7-37',
+        tags: ['私立', '高校', '全日制', '通信併設', 'キャリア教育', '部活動充実'],
+        notes: '普通科・特別進学科・情報科など多様なコースを展開。探究活動と地域連携プロジェクトを重視する私立高校です。'
+      }
+    ];
 
-    tabs.forEach((tab) => {
-      tab.addEventListener('click', () => {
-        const target = tab.dataset.target;
+    const typeLabels = {
+      elementary: '小学校',
+      middle: '中学校',
+      high: '高校'
+    };
 
-        tabs.forEach((item) => {
-          const isActive = item === tab;
-          item.classList.toggle('active', isActive);
-          item.setAttribute('aria-selected', isActive ? 'true' : 'false');
-        });
+    const typeOrder = {
+      elementary: 0,
+      middle: 1,
+      high: 2
+    };
 
-        panels.forEach((panel) => {
-          const shouldShow = panel.dataset.panel === target;
-          panel.classList.toggle('active', shouldShow);
-          panel.toggleAttribute('hidden', !shouldShow);
-        });
+    const state = {
+      types: new Set(Object.keys(typeLabels)),
+      tags: new Set(),
+      term: ''
+    };
+
+    const searchInput = document.getElementById('school-search-input');
+    const typeCheckboxes = document.querySelectorAll('input[name="school-type"]');
+    const tagList = document.getElementById('tag-list');
+    const schoolList = document.getElementById('school-list');
+    const resultSummary = document.getElementById('result-summary');
+    const clearTagsButton = document.getElementById('clear-tag-filter');
+    const resultsRegion = document.querySelector('.results');
+
+    const allTags = Array.from(new Set(SCHOOLS.flatMap((school) => school.tags))).sort((a, b) =>
+      a.localeCompare(b, 'ja')
+    );
+
+    const tagButtons = new Map();
+
+    allTags.forEach((tag) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'tag-chip';
+      button.textContent = tag;
+      button.setAttribute('role', 'option');
+      button.setAttribute('aria-pressed', 'false');
+      button.dataset.tag = tag;
+      button.addEventListener('click', () => {
+        const isSelected = state.tags.has(tag);
+        if (isSelected) {
+          state.tags.delete(tag);
+        } else {
+          state.tags.add(tag);
+        }
+        button.classList.toggle('active', !isSelected);
+        button.setAttribute('aria-pressed', (!isSelected).toString());
+        clearTagsButton.hidden = state.tags.size === 0;
+        render();
+      });
+      tagButtons.set(tag, button);
+      tagList.appendChild(button);
+    });
+
+    clearTagsButton.addEventListener('click', () => {
+      state.tags.clear();
+      tagButtons.forEach((button) => {
+        button.classList.remove('active');
+        button.setAttribute('aria-pressed', 'false');
+      });
+      clearTagsButton.hidden = true;
+      render();
+    });
+
+    searchInput.addEventListener('input', (event) => {
+      state.term = event.target.value.trim();
+      render();
+    });
+
+    typeCheckboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        const { value, checked } = checkbox;
+        if (checked) {
+          state.types.add(value);
+        } else {
+          state.types.delete(value);
+          if (state.types.size === 0) {
+            state.types.add(value);
+            checkbox.checked = true;
+            return;
+          }
+        }
+        render();
       });
     });
+
+    function normalizeText(value) {
+      return value.toString().toLowerCase().normalize('NFKC');
+    }
+
+    function filterSchools() {
+      const normalizedTerm = normalizeText(state.term);
+      return SCHOOLS.filter((school) => state.types.has(school.type))
+        .filter((school) => {
+          if (!normalizedTerm) return true;
+          const keywords = [
+            school.name,
+            school.area,
+            school.address,
+            school.notes,
+            school.programs || '',
+            ...(school.keywords || []),
+            ...school.tags
+          ].join(' ');
+          return normalizeText(keywords).includes(normalizedTerm);
+        })
+        .filter((school) => {
+          if (state.tags.size === 0) return true;
+          return Array.from(state.tags).every((tag) => school.tags.includes(tag));
+        })
+        .sort((a, b) => {
+          const typeDiff = typeOrder[a.type] - typeOrder[b.type];
+          if (typeDiff !== 0) return typeDiff;
+          return a.name.localeCompare(b.name, 'ja');
+        });
+    }
+
+    function addDetail(detailList, term, value) {
+      if (!value) return;
+      const wrapper = document.createElement('div');
+      const dt = document.createElement('dt');
+      dt.textContent = term;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      wrapper.append(dt, dd);
+      detailList.appendChild(wrapper);
+    }
+
+    function render() {
+      resultsRegion.setAttribute('aria-busy', 'true');
+      const results = filterSchools();
+      schoolList.replaceChildren();
+
+      if (results.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = '該当する学校が見つかりませんでした。検索条件を見直してください。';
+        schoolList.appendChild(empty);
+      } else {
+        results.forEach((school) => {
+          const article = document.createElement('article');
+          article.className = 'school-card';
+          article.setAttribute('role', 'listitem');
+          article.dataset.type = school.type;
+
+          const header = document.createElement('header');
+          const typeEl = document.createElement('p');
+          typeEl.className = 'school-type';
+          typeEl.textContent = typeLabels[school.type];
+          const nameEl = document.createElement('h3');
+          nameEl.textContent = school.name;
+          header.append(typeEl, nameEl);
+
+          const areaEl = document.createElement('p');
+          areaEl.className = 'school-area';
+          areaEl.textContent = school.area;
+
+          const detailList = document.createElement('dl');
+          detailList.className = 'school-detail';
+          addDetail(detailList, '所在地', school.address);
+          addDetail(detailList, '特徴', school.notes);
+          addDetail(detailList, '取り組み', school.programs);
+
+          const tagContainer = document.createElement('ul');
+          tagContainer.className = 'school-tags';
+          school.tags.forEach((tag) => {
+            const li = document.createElement('li');
+            li.textContent = tag;
+            tagContainer.appendChild(li);
+          });
+
+          article.append(header, areaEl, detailList, tagContainer);
+          schoolList.appendChild(article);
+        });
+      }
+
+      const total = SCHOOLS.length;
+      const counts = Object.fromEntries(
+        Object.keys(typeLabels).map((type) => [type, results.filter((school) => school.type === type).length])
+      );
+      const summaryParts = Object.keys(typeLabels)
+        .map((type) => `${typeLabels[type]} ${counts[type]}校`)
+        .join(' / ');
+      resultSummary.innerHTML = `<strong>${results.length}校</strong> ヒット / 登録 ${total}校<br><span class="result-breakdown">${summaryParts}</span>`;
+      resultsRegion.setAttribute('aria-busy', 'false');
+    }
+
+    render();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the 学校別 section with a filter panel, free-text search, and results list so visitors can explore every elementary, junior high, and high school in Masuda City
- register detailed metadata and tags for all市内の小中高, enabling combined filtering by学校種と特徴
- refresh the styling to support the new search layout, tag chips, and responsive behaviour

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4bbbd410c8324b0d99535ee80364a