### PR TITLE
Add nearby program listings for schools

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -484,6 +484,112 @@ img {
   font-weight: 600;
 }
 
+.nearby-section {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 16px;
+}
+
+.nearby-section h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.nearby-groups {
+  display: grid;
+  gap: 16px;
+}
+
+.nearby-group {
+  background: rgba(47, 77, 228, 0.06);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.nearby-group h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--primary);
+}
+
+.nearby-programs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.nearby-program {
+  background: var(--card);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  box-shadow: 0 10px 24px rgba(15, 35, 95, 0.08);
+  display: grid;
+  gap: 8px;
+}
+
+.program-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.program-category {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 167, 216, 0.15);
+  color: var(--accent);
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.program-name {
+  font-size: 0.95rem;
+}
+
+.program-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.program-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.program-meta strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.nearby-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (min-width: 768px) {
+  .nearby-groups {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .empty-state {
   margin: 0;
   padding: 28px;

--- a/index.html
+++ b/index.html
@@ -416,6 +416,587 @@
       }
     ];
 
+    const NEARBY_PROGRAMS = {
+      '益田市元町エリア': {
+        kids: [
+          {
+            name: '益田キッズ英会話クラブ',
+            category: '語学',
+            venue: '益田市民学習センター 2F',
+            schedule: '毎週土曜 10:00-11:30',
+            description: 'ALT講師とゲームを通じて英語に触れる小学生向けクラス。フォニックスやスピーキングを自然に身につけます。'
+          },
+          {
+            name: '元町アートラボ',
+            category: 'アート',
+            venue: '元町公民館 創作室',
+            schedule: '隔週日曜 9:30-11:30',
+            description: '絵画・クラフト・デジタルアートを体験できる子ども造形教室。地域アーティストが作品づくりをサポートします。'
+          }
+        ],
+        adults: [
+          {
+            name: '益田夜間ビジネスカレッジ',
+            category: 'キャリア',
+            venue: '益田市産業支援センター',
+            schedule: '毎週火曜 19:00-21:00',
+            description: 'マーケティング基礎とデータ分析を学ぶ社会人講座。地元企業の事例を題材に実践力を高めます。'
+          },
+          {
+            name: '元町ウェルネスピラティス',
+            category: '健康',
+            venue: '元町コミュニティスタジオ',
+            schedule: '毎週木曜 20:00-21:00',
+            description: '体幹を整える夜クラス。初心者歓迎で、仕事帰りにリフレッシュしたい方に人気です。'
+          }
+        ]
+      },
+      '益田市乙吉町エリア': {
+        kids: [
+          {
+            name: '乙吉STEMラボ',
+            category: '科学',
+            venue: '乙吉町学習室',
+            schedule: '毎週土曜 13:30-15:00',
+            description: 'ロボット制作とプログラミングに挑戦する小中学生向け講座。大会出場を目指すチームもあります。'
+          },
+          {
+            name: '益田FCジュニア 乙吉校',
+            category: 'スポーツ',
+            venue: '乙吉多目的グラウンド',
+            schedule: '毎週水・金曜 17:30-19:00',
+            description: '地域密着型のサッカースクール。テクニック指導とチームワークを大切にしたトレーニングが特徴です。'
+          }
+        ],
+        adults: [
+          {
+            name: '乙吉和菓子研究会',
+            category: '文化',
+            venue: '乙吉町公民館 調理室',
+            schedule: '第2・第4水曜 10:00-12:00',
+            description: '季節の上生菓子や地域の銘菓づくりに挑戦。地元菓子職人による丁寧なレクチャーが好評です。'
+          },
+          {
+            name: '夜のストレッチ&ヨガ',
+            category: 'ウェルネス',
+            venue: '乙吉ウェルネススタジオ',
+            schedule: '毎週月曜 19:30-20:30',
+            description: '在宅ワークで凝り固まった身体を整える少人数クラス。呼吸法とストレッチで疲労回復を促します。'
+          }
+        ]
+      },
+      '益田市中吉田町エリア': {
+        kids: [
+          {
+            name: '中吉田サイエンスクラブ',
+            category: '科学',
+            venue: '中吉田交流センター',
+            schedule: '毎月第1土曜 10:00-12:00',
+            description: '実験や観察を通じて科学の楽しさを体感。地域の理科教員OBが指導します。'
+          },
+          {
+            name: '吉田アフタースクール英語',
+            category: '語学',
+            venue: '吉田地区学習支援室',
+            schedule: '毎週火・木曜 16:00-18:00',
+            description: '放課後に通える英語学習サポート。宿題サポートと英検対策も実施しています。'
+          }
+        ],
+        adults: [
+          {
+            name: '中吉田ナイトランクラブ',
+            category: 'スポーツ',
+            venue: '中吉田町周回コース',
+            schedule: '毎週水曜 20:00集合',
+            description: '仕事終わりに集まるランニングサークル。ペース別グループで初心者も参加しやすい環境です。'
+          },
+          {
+            name: '季節のやさしい薬膳教室',
+            category: 'ライフスタイル',
+            venue: '中吉田町コミュニティ台所',
+            schedule: '毎月第3土曜 14:00-16:00',
+            description: '身近な食材でできる薬膳レシピを学ぶ講座。家庭で再現しやすいメニューが人気です。'
+          }
+        ]
+      },
+      '益田市高津町エリア': {
+        kids: [
+          {
+            name: '高津ビーチアクアキッズ',
+            category: 'スポーツ',
+            venue: '高津海浜プール',
+            schedule: '夏季限定 毎週日曜 9:00-11:00',
+            description: '水泳とライフセービングの基礎を学ぶプログラム。海辺の安全教室もセットで実施します。'
+          },
+          {
+            name: '高津ミュージックアンサンブル',
+            category: '音楽',
+            venue: '高津文化ホール',
+            schedule: '毎週土曜 15:00-17:00',
+            description: '吹奏楽と合唱を体験できる音楽教室。演奏会や地域イベントへの出演機会があります。'
+          }
+        ],
+        adults: [
+          {
+            name: '高津シーサイドヨガ',
+            category: 'ウェルネス',
+            venue: '高津海浜公園 芝生広場',
+            schedule: '毎週土曜 7:30-8:30',
+            description: '朝の海風を感じながら行うリフレッシュヨガ。マインドフルネスのミニレクチャー付き。'
+          },
+          {
+            name: '高津クラフトビール講座',
+            category: '食・飲',
+            venue: '高津町まちの研究室',
+            schedule: '毎月第2金曜 19:00-21:00',
+            description: '地元産ホップを使ったビールづくり体験。発酵の仕組みとフードペアリングを学びます。'
+          }
+        ]
+      },
+      '益田市飯田町エリア': {
+        kids: [
+          {
+            name: '飯田イングリッシュアフタースクール',
+            category: '語学',
+            venue: '飯田まちの教室',
+            schedule: '毎週火・金曜 17:00-18:30',
+            description: '英語で工作や科学実験に挑戦。英語の4技能を楽しく伸ばすアクティブラーニング型クラスです。'
+          },
+          {
+            name: '飯田ジュニア書道',
+            category: '文化',
+            venue: '飯田町文化センター',
+            schedule: '毎週土曜 14:00-15:30',
+            description: '基礎から段位取得までサポートする書道教室。毛筆・硬筆の両方を丁寧に指導します。'
+          }
+        ],
+        adults: [
+          {
+            name: '飯田まちゼミ パソコン塾',
+            category: 'キャリア',
+            venue: '飯田町商店街オフィス',
+            schedule: '全4回 / 平日夜 19:00-20:30',
+            description: 'Excel・Wordの基礎と業務効率化テクニックを学ぶ短期講座。少人数制で質問しやすい環境です。'
+          },
+          {
+            name: '飯田サウンドサロン',
+            category: '音楽',
+            venue: '飯田交流スタジオ',
+            schedule: '毎週金曜 20:00-21:30',
+            description: '大人のためのバンド・セッション教室。楽器初心者も基礎から参加できるプログラムです。'
+          }
+        ]
+      },
+      '益田市東町エリア': {
+        kids: [
+          {
+            name: '東町神楽キッズクラブ',
+            category: '文化',
+            venue: '東町神楽殿',
+            schedule: '毎週木曜 18:00-19:30',
+            description: '石見神楽の舞と囃子を学ぶ伝統芸能教室。衣装体験や地域の祭り出演もあります。'
+          },
+          {
+            name: '益田STEAMラボ 東町',
+            category: '科学',
+            venue: '益田市立図書館ラボ室',
+            schedule: '毎週日曜 10:30-12:00',
+            description: '3Dプリンタや電子工作に触れながら創造力を育むプログラム。中高生の自由研究サポートも充実。'
+          }
+        ],
+        adults: [
+          {
+            name: '東町歴史まち歩き講座',
+            category: '文化',
+            venue: '東町観光案内所 集合',
+            schedule: '毎月第1日曜 9:00-11:30',
+            description: '史跡を巡りながら郷土史を学ぶフィールドワーク型講座。案内人による解説付きです。'
+          },
+          {
+            name: '東町イブニングピラティス',
+            category: 'ウェルネス',
+            venue: '東町コミュニティホール',
+            schedule: '毎週水曜 19:30-20:30',
+            description: 'コアを整えるナイトクラス。少人数制で姿勢改善と体力向上をサポートします。'
+          }
+        ]
+      },
+      '益田市高津町横田エリア': {
+        kids: [
+          {
+            name: '横田サッカースクール',
+            category: 'スポーツ',
+            venue: '横田交流広場',
+            schedule: '毎週火・土曜 17:00-18:30',
+            description: '複式学級の子どもたちが集うサッカークラブ。個々のレベルに合わせた指導で自信を育みます。'
+          },
+          {
+            name: '横田アウトドアアドベンチャー',
+            category: '自然体験',
+            venue: '横田里山フィールド',
+            schedule: '毎月第2土曜 9:00-12:00',
+            description: '里山での自然観察・焚き火・クラフトを楽しむ探検教室。親子参加も歓迎です。'
+          }
+        ],
+        adults: [
+          {
+            name: '横田ナチュラルガーデン倶楽部',
+            category: 'ライフスタイル',
+            venue: '横田コミュニティガーデン',
+            schedule: '隔週日曜 8:30-10:30',
+            description: '無農薬ハーブや季節野菜を育てるガーデニングサークル。講師による園芸ワークが人気です。'
+          },
+          {
+            name: '横田ウィークリーヨガ',
+            category: 'ウェルネス',
+            venue: '横田地区交流センター',
+            schedule: '毎週金曜 19:00-20:00',
+            description: '呼吸法とストレッチで心身を整える夜ヨガ。初心者向けの基礎クラスです。'
+          }
+        ]
+      },
+      '益田市二条町エリア': {
+        kids: [
+          {
+            name: '二条川ネイチャースクール',
+            category: '自然体験',
+            venue: '二条町 河川敷',
+            schedule: '毎月第3土曜 9:30-12:00',
+            description: '川遊びと環境学習を組み合わせたアウトドアプログラム。地域のNPOが安全管理を行います。'
+          },
+          {
+            name: '二条里山アートクラブ',
+            category: 'アート',
+            venue: '二条町古民家スタジオ',
+            schedule: '毎週土曜 13:00-15:00',
+            description: '自然素材を活用した造形活動が中心。里山の植物を使った染色体験も人気です。'
+          }
+        ],
+        adults: [
+          {
+            name: '二条発酵ラボ',
+            category: '食',
+            venue: '二条町交流台所',
+            schedule: '毎月第2木曜 10:00-12:00',
+            description: '味噌・麹づくりなど発酵食品に特化したワークショップ。発酵マイスターが指導します。'
+          },
+          {
+            name: '二条温泉ヨガリトリート',
+            category: 'ウェルネス',
+            venue: '二条温泉 休憩ラウンジ',
+            schedule: '毎週日曜 18:00-19:30',
+            description: '温泉入浴とセットで楽しむリラクゼーションヨガ。週末の疲れを癒したい人に人気です。'
+          }
+        ]
+      },
+      '益田市七尾町エリア': {
+        kids: [
+          {
+            name: '七尾マリンキッズクラブ',
+            category: '自然体験',
+            venue: '七尾町海浜センター',
+            schedule: '春〜秋 毎月第1日曜 10:00-12:00',
+            description: '磯遊びやシーカヤック体験を通じて海の生き物を学ぶ体験教室。安全講習付きです。'
+          },
+          {
+            name: '七尾太鼓ジュニア',
+            category: '文化',
+            venue: '七尾地区公民館',
+            schedule: '毎週金曜 18:00-19:30',
+            description: '地域の太鼓グループが指導するリズム教室。地域の祭り出演が目標です。'
+          }
+        ],
+        adults: [
+          {
+            name: '七尾シーサイドウォーキング',
+            category: 'スポーツ',
+            venue: '七尾町海岸遊歩道',
+            schedule: '毎週水曜 8:00集合',
+            description: '海辺を歩く健康づくりプログラム。ストレッチと海洋環境ミニ講座を組み合わせています。'
+          },
+          {
+            name: '七尾クラフト珈琲講座',
+            category: 'ライフスタイル',
+            venue: '七尾港カフェ',
+            schedule: '毎月第4土曜 15:00-17:00',
+            description: '自家焙煎コーヒーの淹れ方とフードペアリングを学ぶ少人数講座。テイスティング体験付き。'
+          }
+        ]
+      },
+      '益田市鎌手町エリア': {
+        kids: [
+          {
+            name: '鎌手神楽ジュニア講座',
+            category: '文化',
+            venue: '鎌手神社 神楽殿',
+            schedule: '毎週火曜 18:00-19:30',
+            description: '舞と囃子の基礎から指導する神楽教室。保護者の見学も可能です。'
+          },
+          {
+            name: '鎌手ビーチサーフィンスクール',
+            category: 'スポーツ',
+            venue: '鎌手海岸',
+            schedule: '夏季限定 土日 9:00-11:00',
+            description: 'プロサーファー監修のジュニアクラス。海の安全講習とセットで実施します。'
+          }
+        ],
+        adults: [
+          {
+            name: '鎌手漁師めし料理塾',
+            category: '食',
+            venue: '鎌手町漁協施設',
+            schedule: '毎月第2土曜 10:30-13:00',
+            description: '旬の魚介を使った漁師料理を学ぶ料理教室。地元漁師による漁談も楽しめます。'
+          },
+          {
+            name: '鎌手ビーチフィット',
+            category: 'ウェルネス',
+            venue: '鎌手海岸特設エリア',
+            schedule: '毎週土曜 7:00-8:00',
+            description: '砂浜でのサーキットトレーニング。自然の抵抗を活かした全身エクササイズです。'
+          }
+        ]
+      },
+      '益田市匹見町エリア': {
+        kids: [
+          {
+            name: '匹見アウトドアアカデミー',
+            category: '自然体験',
+            venue: '匹見峡ビジターセンター',
+            schedule: '毎月第2土曜 9:00-12:00',
+            description: '渓流トレッキングやツリークライミングが楽しめる自然学校。季節ごとの体験プログラムを用意。'
+          },
+          {
+            name: '匹見木工キッズラボ',
+            category: 'クラフト',
+            venue: '匹見森林体験館',
+            schedule: '毎月第4土曜 13:00-15:30',
+            description: '地域材を使った木工クラフトに挑戦。親子で参加できる人気講座です。'
+          }
+        ],
+        adults: [
+          {
+            name: '匹見マウンテンフィット',
+            category: 'スポーツ',
+            venue: '匹見運動公園',
+            schedule: '毎週日曜 8:30-10:00',
+            description: '山間地の地形を活かしたトレイルランとクロスフィットのハイブリッドトレーニング。'
+          },
+          {
+            name: '匹見薬草ガーデン講座',
+            category: 'ライフスタイル',
+            venue: '匹見薬草園',
+            schedule: '毎月第1土曜 10:00-12:00',
+            description: '薬草の育て方とセルフケアに活かす方法を学ぶ講座。ハーブティーの試飲付きです。'
+          }
+        ]
+      },
+      '益田市美都町エリア': {
+        kids: [
+          {
+            name: '美都茶畑体験スクール',
+            category: '農業体験',
+            venue: '美都町 茶園',
+            schedule: '春・秋シーズン 土曜 9:00-12:00',
+            description: '茶摘みや製茶体験を通じて地域の産業を学ぶ体験型プログラム。親子参加も歓迎です。'
+          },
+          {
+            name: '美都リコーダーアンサンブル',
+            category: '音楽',
+            venue: '美都文化センター 音楽室',
+            schedule: '毎週金曜 17:00-18:00',
+            description: '基礎からアンサンブル演奏を楽しむ音楽クラブ。発表会や地域イベントでの演奏機会があります。'
+          }
+        ],
+        adults: [
+          {
+            name: '美都発酵食カレッジ',
+            category: '食',
+            venue: '美都町農産加工室',
+            schedule: '毎月第2土曜 13:30-16:00',
+            description: '麹づくりや季節の保存食を学ぶ講座。地域の発酵文化を継承することを目指しています。'
+          },
+          {
+            name: '美都ナイトリフレッシュヨガ',
+            category: 'ウェルネス',
+            venue: '美都温泉 多目的室',
+            schedule: '毎週火曜 19:30-20:30',
+            description: '温泉入浴とセットでリラックスできる夜ヨガ。ストレスケアと睡眠の質向上をサポートします。'
+          }
+        ]
+      },
+      '益田市美都町都茂エリア': {
+        kids: [
+          {
+            name: '都茂リバートレイルクラブ',
+            category: '自然体験',
+            venue: '都茂川周辺',
+            schedule: '毎月第1土曜 9:30-12:00',
+            description: '川遊びとネイチャーゲームで自然を学ぶアウトドア教室。安全講習付きで初参加でも安心です。'
+          },
+          {
+            name: '都茂里山サイエンス',
+            category: '科学',
+            venue: '都茂地域センター',
+            schedule: '隔月第3日曜 10:00-12:00',
+            description: '植物観察や星空観測を通して理科への関心を高めるフィールドワーク型講座。'
+          }
+        ],
+        adults: [
+          {
+            name: '都茂薬草と養生講座',
+            category: 'ライフスタイル',
+            venue: '都茂薬草研究室',
+            schedule: '毎月第2日曜 13:00-15:00',
+            description: '山野草の見分け方と家庭で活かすセルフケア方法を学びます。試飲とレシピ冊子付き。'
+          },
+          {
+            name: '都茂木工アトリエ',
+            category: 'クラフト',
+            venue: '都茂木工房',
+            schedule: '毎週土曜 14:00-16:30',
+            description: '家具職人が指導する木工ワークショップ。暮らしの小物から家具づくりまで挑戦できます。'
+          }
+        ]
+      },
+      '益田市染羽町エリア': {
+        kids: [
+          {
+            name: '染羽イングリッシュキャンプ',
+            category: '語学',
+            venue: '染羽町国際交流センター',
+            schedule: '夏休み集中 5日間',
+            description: '外国人留学生と交流しながら英語漬けで過ごす短期集中プログラム。プレゼン発表も実施します。'
+          },
+          {
+            name: '染羽ジュニアバスケット',
+            category: 'スポーツ',
+            venue: '染羽体育館',
+            schedule: '毎週火・金曜 17:30-19:00',
+            description: '基礎体力づくりとチーム練習をバランスよく行うジュニアクラブ。大会出場を目指します。'
+          }
+        ],
+        adults: [
+          {
+            name: '染羽イブニング大学',
+            category: 'キャリア',
+            venue: '染羽町学習ラボ',
+            schedule: '隔週水曜 19:00-21:00',
+            description: 'ビジネスリーダーを目指す社会人向け講座。プレゼン・ファシリテーション・DX入門を学びます。'
+          },
+          {
+            name: '染羽ナイトジャズセッション',
+            category: '音楽',
+            venue: '染羽ジャズバー',
+            schedule: '毎月第3金曜 20:00-22:00',
+            description: 'アドリブ演奏を学びながらセッションを楽しむ夜クラス。初心者向けレクチャーも用意しています。'
+          }
+        ]
+      },
+      '益田市久城町エリア': {
+        kids: [
+          {
+            name: '久城プログラミングキッズ',
+            category: 'ICT',
+            venue: '久城町イノベーションルーム',
+            schedule: '毎週土曜 10:00-11:30',
+            description: 'Scratchやmicro:bitでゲーム制作に挑戦。発表会で成果を披露します。'
+          },
+          {
+            name: '久城ダンススタジオ ジュニア',
+            category: 'ダンス',
+            venue: '久城ダンススタジオ',
+            schedule: '毎週木曜 17:00-18:30',
+            description: 'ヒップホップとK-POPカバーダンスを学ぶクラス。初心者でも基礎から丁寧に指導します。'
+          }
+        ],
+        adults: [
+          {
+            name: '久城マネジメントスクール',
+            category: 'キャリア',
+            venue: '久城町学びの館',
+            schedule: '隔週金曜 19:00-21:00',
+            description: '組織マネジメントとチームづくりを学ぶ社会人講座。ケーススタディとディスカッション中心。'
+          },
+          {
+            name: '久城フィットネスブートキャンプ',
+            category: 'スポーツ',
+            venue: '久城体育館',
+            schedule: '毎週月・木曜 20:00-21:00',
+            description: 'サーキットトレーニングとHIITを組み合わせた集中プログラム。短時間で効果を実感できます。'
+          }
+        ]
+      },
+      '益田市昭和町エリア': {
+        kids: [
+          {
+            name: '昭和ロボティクスラボ',
+            category: '科学',
+            venue: '昭和町テクノロジーセンター',
+            schedule: '毎週土曜 14:00-16:00',
+            description: 'ロボット競技会を目指す小中学生チーム。プログラミングと機械設計を実践的に学びます。'
+          },
+          {
+            name: '昭和ジュニアバレーボール',
+            category: 'スポーツ',
+            venue: '昭和町体育館',
+            schedule: '毎週火・木曜 17:30-19:00',
+            description: 'ミニバレーから始める初心者歓迎のクラブ。基礎体力づくりとチームワークを大切にしています。'
+          }
+        ],
+        adults: [
+          {
+            name: '昭和町ビジネス英語塾',
+            category: '語学',
+            venue: '昭和町学習スタジオ',
+            schedule: '毎週水曜 19:30-21:00',
+            description: '会議やメールで使える実践英語を学ぶ社会人講座。オンライン併用で通いやすいと好評です。'
+          },
+          {
+            name: '昭和シティラン&トレイル',
+            category: 'スポーツ',
+            venue: '昭和町駅前集合',
+            schedule: '毎週日曜 7:00-9:00',
+            description: '市街地と山道を走るクロストレーニングサークル。レベル別グループで安心して参加できます。'
+          }
+        ]
+      },
+      '益田市三宅町エリア': {
+        kids: [
+          {
+            name: '三宅クリエイティブラボ',
+            category: 'アート',
+            venue: '三宅町クリエイティブハブ',
+            schedule: '毎週土曜 10:00-12:00',
+            description: '動画制作・写真・デザインを学ぶ中高生向け講座。作品は地域イベントで発表します。'
+          },
+          {
+            name: '三宅イマージョン英語',
+            category: '語学',
+            venue: '三宅ラーニングスペース',
+            schedule: '毎週水曜 17:00-18:30',
+            description: '英語で理科や社会を学ぶCLILスタイルの授業。プレゼンテーション力も鍛えます。'
+          }
+        ],
+        adults: [
+          {
+            name: '三宅ナイトクリエイティブ講座',
+            category: 'キャリア',
+            venue: '三宅町クリエイティブハブ',
+            schedule: '毎週木曜 19:00-21:00',
+            description: 'デザイン思考とプレゼン術を学ぶ社会人講座。地域課題解決をテーマに実践します。'
+          },
+          {
+            name: '三宅メディテーションサークル',
+            category: 'ウェルネス',
+            venue: '三宅町ホリスティックルーム',
+            schedule: '毎週火曜 20:00-21:00',
+            description: 'マインドフルネス瞑想と呼吸法で心を整える夜のサークル。オンライン参加も可能です。'
+          }
+        ]
+      }
+    };
+
     const typeLabels = {
       elementary: '小学校',
       middle: '中学校',
@@ -546,6 +1127,78 @@
       detailList.appendChild(wrapper);
     }
 
+    function createProgramMetaItem(term, value) {
+      if (!value) return null;
+      const li = document.createElement('li');
+      const strong = document.createElement('strong');
+      strong.textContent = `${term}:`;
+      li.append(strong, document.createTextNode(` ${value}`));
+      return li;
+    }
+
+    function createProgramList(title, programs, audience) {
+      const section = document.createElement('section');
+      section.className = `nearby-group nearby-${audience}`;
+
+      const heading = document.createElement('h5');
+      heading.textContent = title;
+      section.appendChild(heading);
+
+      if (!programs || programs.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'nearby-empty';
+        empty.textContent = '現在登録されている講座はありません。';
+        section.appendChild(empty);
+        return section;
+      }
+
+      const list = document.createElement('ul');
+      list.className = 'nearby-programs';
+
+      programs.forEach((program) => {
+        const item = document.createElement('li');
+        item.className = 'nearby-program';
+
+        const header = document.createElement('div');
+        header.className = 'program-header';
+
+        const category = document.createElement('span');
+        category.className = 'program-category';
+        category.textContent = program.category;
+
+        const name = document.createElement('strong');
+        name.className = 'program-name';
+        name.textContent = program.name;
+
+        header.append(category, name);
+
+        const description = document.createElement('p');
+        description.className = 'program-description';
+        description.textContent = program.description;
+
+        const meta = document.createElement('ul');
+        meta.className = 'program-meta';
+
+        const venue = createProgramMetaItem('会場', program.venue);
+        const schedule = createProgramMetaItem('スケジュール', program.schedule);
+        const contact = createProgramMetaItem('問い合わせ', program.contact);
+
+        [venue, schedule, contact].forEach((entry) => {
+          if (entry) meta.appendChild(entry);
+        });
+
+        item.append(header, description);
+        if (meta.childElementCount > 0) {
+          item.appendChild(meta);
+        }
+
+        list.appendChild(item);
+      });
+
+      section.appendChild(list);
+      return section;
+    }
+
     function render() {
       resultsRegion.setAttribute('aria-busy', 'true');
       const results = filterSchools();
@@ -590,6 +1243,27 @@
           });
 
           article.append(header, areaEl, detailList, tagContainer);
+
+          const nearbyData = NEARBY_PROGRAMS[school.area];
+          if (nearbyData) {
+            const nearbySection = document.createElement('div');
+            nearbySection.className = 'nearby-section';
+
+            const nearbyHeading = document.createElement('h4');
+            nearbyHeading.textContent = '周辺スクール情報';
+            nearbySection.appendChild(nearbyHeading);
+
+            const nearbyGroups = document.createElement('div');
+            nearbyGroups.className = 'nearby-groups';
+            nearbyGroups.append(
+              createProgramList('子ども向けスクール', nearbyData.kids, 'kids'),
+              createProgramList('大人向けスクール', nearbyData.adults, 'adults')
+            );
+
+            nearbySection.appendChild(nearbyGroups);
+            article.appendChild(nearbySection);
+          }
+
           schoolList.appendChild(article);
         });
       }


### PR DESCRIPTION
## Summary
- add detailed nearby program data for各学校エリア with child and adult categories
- extend schoolカード rendering to surface周辺スクール情報 and helper生成ロジック
- style the new nearby programセクション for視認性とレスポンシブ対応

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4bfa1d7cc832485bad0698c338de7