### PR TITLE
Limit school tags and expand nearby program listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@
         type: 'elementary',
         area: '益田市元町エリア',
         address: '益田市元町6-30',
-        tags: ['公立', '小学校', '市街地', 'ICT活用', '放課後子ども教室', 'コミュニティ・スクール'],
+        tags: ['益田市立益田小学校', 'ICT活用'],
         notes: '市街地中心部にある大規模校。タブレット学習や英語専科など先進的な授業を進め、地域ボランティアと連携したキャリア教育も盛んです。',
         programs: '地域の読み聞かせボランティアや放課後クラブと連携した学びを展開。'
       },
@@ -233,7 +233,7 @@
         type: 'elementary',
         area: '益田市乙吉町エリア',
         address: '益田市乙吉町イ114',
-        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '自然体験'],
+        tags: ['益田市立吉田小学校', 'ICT活用'],
         notes: '吉田川沿いの住宅地に位置し、地域行事と連動した学びが特徴。校内農園を活用した食育に取り組んでいます。'
       },
       {
@@ -241,7 +241,7 @@
         type: 'elementary',
         area: '益田市中吉田町エリア',
         address: '益田市中吉田町37',
-        tags: ['公立', '小学校', '市街地', '小規模校', 'コミュニティ・スクール'],
+        tags: ['益田市立中西小学校', 'ICT活用'],
         notes: '少人数ならではのきめ細かなサポートが魅力。地域企業と連携したキャリア体験学習を継続的に実施しています。'
       },
       {
@@ -249,7 +249,7 @@
         type: 'elementary',
         area: '益田市高津町エリア',
         address: '益田市高津町イ2320',
-        tags: ['公立', '小学校', '沿岸部', 'コミュニティ・スクール', 'スポーツ'],
+        tags: ['益田市立高津小学校', 'ICT活用'],
         notes: '日本海に近い高津地区の拠点校。水辺の環境を生かした総合学習や海洋教育、少年スポーツが盛んな学校です。'
       },
       {
@@ -257,7 +257,7 @@
         type: 'elementary',
         area: '益田市飯田町エリア',
         address: '益田市飯田町21-2',
-        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '国際交流'],
+        tags: ['益田市立飯田小学校', 'ICT活用'],
         notes: '益田駅に近い立地。国際理解教育やALTとの交流、読書活動が充実しており、地域図書館との連携も進んでいます。'
       },
       {
@@ -265,7 +265,7 @@
         type: 'elementary',
         area: '益田市乙吉町エリア',
         address: '益田市乙吉町イ331-3',
-        tags: ['公立', '小学校', '市街地', 'コミュニティ・スクール', '児童クラブ'],
+        tags: ['益田市立西益田小学校', 'ICT活用'],
         notes: '住宅地が広がる西益田地区の中核校。地域と協働した防災学習や児童クラブを併設し、安全・安心の体制を整えています。'
       },
       {
@@ -273,7 +273,7 @@
         type: 'elementary',
         area: '益田市東町エリア',
         address: '益田市東町12-6',
-        tags: ['公立', '小学校', '市街地', '文化財学習', 'コミュニティ・スクール'],
+        tags: ['益田市立東仙道小学校', 'ICT活用'],
         notes: '歴史ある寺社が多い東仙道地区の伝統校。石見神楽など地域文化を生かした総合学習が特色です。'
       },
       {
@@ -281,7 +281,7 @@
         type: 'elementary',
         area: '益田市高津町横田エリア',
         address: '益田市高津町イ2955',
-        tags: ['公立', '小学校', '市街地', '小規模校', '自然体験'],
+        tags: ['益田市立横田小学校', 'ICT活用'],
         notes: '周囲を田園が囲む横田地区の学校。里山を活用した自然体験や複式学級による丁寧な指導が魅力です。'
       },
       {
@@ -289,7 +289,7 @@
         type: 'elementary',
         area: '益田市二条町エリア',
         address: '益田市二条町イ127',
-        tags: ['公立', '小学校', '中山間地域', '小規模校', 'スクールバス'],
+        tags: ['益田市立二条小学校', 'ICT活用'],
         notes: '匹見川上流に近い中山間地域の学校。スクールバス運行や地域行事と連動した学習が盛んです。'
       },
       {
@@ -297,7 +297,7 @@
         type: 'elementary',
         area: '益田市七尾町エリア',
         address: '益田市七尾町8',
-        tags: ['公立', '小学校', '沿岸部', '小規模校', '自然体験'],
+        tags: ['益田市立七尾小学校', 'ICT活用'],
         notes: '海と山に囲まれた七尾町の学校。海洋体験や森林体験を通じたふるさと教育を実践しています。'
       },
       {
@@ -305,7 +305,7 @@
         type: 'elementary',
         area: '益田市鎌手町エリア',
         address: '益田市鎌手町ロ77-3',
-        tags: ['公立', '小学校', '沿岸部', 'コミュニティ・スクール', 'スクールバス'],
+        tags: ['益田市立鎌手小学校', 'ICT活用'],
         notes: '日本海沿いの漁業地域に位置。神楽学習や海の安全教室など地域密着の学びが魅力です。'
       },
       {
@@ -313,7 +313,7 @@
         type: 'elementary',
         area: '益田市匹見町エリア',
         address: '益田市匹見町匹見イ982',
-        tags: ['公立', '小学校', '山間地域', '小規模校', 'スクールバス', 'コミュニティ・スクール'],
+        tags: ['益田市立匹見小学校', 'ICT活用'],
         notes: '中国山地の豊かな自然に囲まれた小規模校。森林環境教育や地域人材による体験学習が充実しています。',
         programs: '山村留学制度「匹見Rise」など全国からの受け入れ実績があります。'
       },
@@ -322,7 +322,7 @@
         type: 'elementary',
         area: '益田市美都町エリア',
         address: '益田市美都町都茂1186',
-        tags: ['公立', '小学校', '山間地域', '小規模校', 'コミュニティ・スクール'],
+        tags: ['益田市立美都小学校', 'ICT活用'],
         notes: '旧美都町の中心部にある小学校。茶摘みや郷土芸能など地域資源を活かした学習を展開しています。'
       },
       {
@@ -330,7 +330,7 @@
         type: 'elementary',
         area: '益田市美都町都茂エリア',
         address: '益田市美都町都茂1523',
-        tags: ['公立', '小学校', '山間地域', '小規模校', 'スクールバス'],
+        tags: ['益田市立都茂小学校', 'ICT活用'],
         notes: '山間地にある複式学級の学校。森づくり学習や地域との協働による体験活動が特色です。'
       },
       {
@@ -338,7 +338,7 @@
         type: 'middle',
         area: '益田市染羽町エリア',
         address: '益田市染羽町1-5',
-        tags: ['公立', '中学校', '市街地', '部活動充実', '探究学習'],
+        tags: ['益田市立益田中学校', 'ICT活用'],
         notes: '市中心部の総合校。部活動数が多く、地域と連動した総合的な探究学習を推進しています。'
       },
       {
@@ -346,7 +346,7 @@
         type: 'middle',
         area: '益田市高津町エリア',
         address: '益田市高津町イ2360',
-        tags: ['公立', '中学校', '沿岸部', '部活動充実', 'キャリア教育'],
+        tags: ['益田市立高津中学校', 'ICT活用'],
         notes: '高津地区の拠点中学校。キャリア教育や地域企業との連携授業を展開し、海洋教育も取り入れています。'
       },
       {
@@ -354,7 +354,7 @@
         type: 'middle',
         area: '益田市高津町横田エリア',
         address: '益田市高津町イ2745',
-        tags: ['公立', '中学校', '市街地', '小規模校', '地域連携'],
+        tags: ['益田市立横田中学校', 'ICT活用'],
         notes: '小規模ながら地域密着型の学校。小中連携による英語強化や農業体験が特徴です。'
       },
       {
@@ -362,7 +362,7 @@
         type: 'middle',
         area: '益田市匹見町エリア',
         address: '益田市匹見町匹見イ1104',
-        tags: ['公立', '中学校', '山間地域', '小規模校', '寮・下宿対応', 'スクールバス'],
+        tags: ['益田市立匹見中学校', 'ICT活用'],
         notes: '中国山地の自然の中で学ぶ中学校。遠距離通学を支える下宿制度や山村留学を受け入れています。',
         programs: '森林環境学習やカヌー体験など、アウトドアプログラムが豊富です。'
       },
@@ -371,7 +371,7 @@
         type: 'middle',
         area: '益田市美都町エリア',
         address: '益田市美都町都茂1186-2',
-        tags: ['公立', '中学校', '山間地域', '小規模校', 'コミュニティ・スクール'],
+        tags: ['益田市立美都中学校', 'ICT活用'],
         notes: '地域ぐるみで学びを支えるコミュニティ・スクール。茶どころ美都の文化を活かしたふるさと学習を行っています。'
       },
       {
@@ -379,7 +379,7 @@
         type: 'middle',
         area: '益田市久城町エリア',
         address: '益田市久城町457',
-        tags: ['私立', '中学校', '市街地', '中高一貫', '探究学習', '部活動充実'],
+        tags: ['益田東中学校', 'ICT活用'],
         notes: '益田東高等学校と連携した中高一貫校。難関大学進学を見据えた探究型学習と強化指定クラブが充実しています。'
       },
       {
@@ -387,7 +387,7 @@
         type: 'high',
         area: '益田市東町エリア',
         address: '益田市東町20-33',
-        tags: ['公立', '高校', '全日制', '普通科', '進学校', '探究学習', '部活動充実'],
+        tags: ['島根県立益田高等学校', 'ICT活用'],
         notes: '県内屈指の進学校。理数探究類型や地域探究プロジェクトを推進し、全国規模の学びの機会が豊富です。'
       },
       {
@@ -395,7 +395,7 @@
         type: 'high',
         area: '益田市昭和町エリア',
         address: '益田市昭和町12-1',
-        tags: ['公立', '高校', '全日制', '専門学科', 'キャリア教育', '部活動充実'],
+        tags: ['島根県立益田翔陽高等学校', 'ICT活用'],
         notes: '普通科に加え産業系・福祉系など多彩な学科を設置。地域企業と連動した実習や資格取得支援が手厚い学校です。'
       },
       {
@@ -403,7 +403,7 @@
         type: 'high',
         area: '益田市久城町エリア',
         address: '益田市久城町457',
-        tags: ['私立', '高校', '全日制', '中高一貫', '進学コース', '部活動強化'],
+        tags: ['益田東高等学校', 'ICT活用'],
         notes: '中高一貫の私立校。特別進学・グローバルなど複数コースを設置し、寮完備で全国から生徒を受け入れています。'
       },
       {
@@ -411,7 +411,7 @@
         type: 'high',
         area: '益田市三宅町エリア',
         address: '益田市三宅町7-37',
-        tags: ['私立', '高校', '全日制', '通信併設', 'キャリア教育', '部活動充実'],
+        tags: ['明誠高等学校', 'ICT活用'],
         notes: '普通科・特別進学科・情報科など多様なコースを展開。探究活動と地域連携プロジェクトを重視する私立高校です。'
       }
     ];
@@ -448,6 +448,13 @@
             venue: '元町コミュニティスタジオ',
             schedule: '毎週木曜 20:00-21:00',
             description: '体幹を整える夜クラス。初心者歓迎で、仕事帰りにリフレッシュしたい方に人気です。'
+          },
+          {
+            name: '元町イブニングプログラミング',
+            category: 'ICT',
+            venue: '元町コワーキングスペース',
+            schedule: '隔週水曜 19:30-21:00',
+            description: 'ノーコードツールと自動化を学ぶ少人数講座。実務課題を持ち寄りサポートを受けられます。'
           }
         ]
       },
@@ -482,6 +489,13 @@
             venue: '乙吉ウェルネススタジオ',
             schedule: '毎週月曜 19:30-20:30',
             description: '在宅ワークで凝り固まった身体を整える少人数クラス。呼吸法とストレッチで疲労回復を促します。'
+          },
+          {
+            name: '乙吉イブニングDX実践',
+            category: 'キャリア',
+            venue: '乙吉町デジタルラボ',
+            schedule: '第1・第3木曜 19:00-21:00',
+            description: '業務自動化やデータ可視化をテーマにした実務者向け講座。地域企業との共同プロジェクトも実施します。'
           }
         ]
       },
@@ -516,6 +530,13 @@
             venue: '中吉田町コミュニティ台所',
             schedule: '毎月第3土曜 14:00-16:00',
             description: '身近な食材でできる薬膳レシピを学ぶ講座。家庭で再現しやすいメニューが人気です。'
+          },
+          {
+            name: '中吉田デザインラボ',
+            category: 'キャリア',
+            venue: '中吉田クリエイティブルーム',
+            schedule: '隔週木曜 19:00-21:00',
+            description: 'プレゼン資料やチラシ作成を学ぶグラフィックデザイン講座。地域イベントの制作支援も行います。'
           }
         ]
       },
@@ -550,6 +571,13 @@
             venue: '高津町まちの研究室',
             schedule: '毎月第2金曜 19:00-21:00',
             description: '地元産ホップを使ったビールづくり体験。発酵の仕組みとフードペアリングを学びます。'
+          },
+          {
+            name: '高津デジタル写真サロン',
+            category: 'アート',
+            venue: '高津カルチャーハウス',
+            schedule: '隔週水曜 19:00-20:30',
+            description: '夜景や海景の撮影テクニックを学ぶ写真講座。撮影後のレタッチ方法も解説します。'
           }
         ]
       },
@@ -584,6 +612,13 @@
             venue: '飯田交流スタジオ',
             schedule: '毎週金曜 20:00-21:30',
             description: '大人のためのバンド・セッション教室。楽器初心者も基礎から参加できるプログラムです。'
+          },
+          {
+            name: '飯田イブニングガーデニング',
+            category: 'ライフスタイル',
+            venue: '飯田コミュニティガーデン',
+            schedule: '毎週水曜 18:30-20:00',
+            description: 'ハーブと季節の草花を育てる夜のガーデニング教室。庭づくりのデザインも学べます。'
           }
         ]
       },
@@ -618,6 +653,13 @@
             venue: '東町コミュニティホール',
             schedule: '毎週水曜 19:30-20:30',
             description: 'コアを整えるナイトクラス。少人数制で姿勢改善と体力向上をサポートします。'
+          },
+          {
+            name: '東町ナイトスキルブートキャンプ',
+            category: 'キャリア',
+            venue: '東町イノベーションスペース',
+            schedule: '毎週木曜 19:00-21:00',
+            description: 'プレゼンテーションとチームファシリテーションを鍛える社会人向け集中講座です。'
           }
         ]
       },
@@ -652,6 +694,13 @@
             venue: '横田地区交流センター',
             schedule: '毎週金曜 19:00-20:00',
             description: '呼吸法とストレッチで心身を整える夜ヨガ。初心者向けの基礎クラスです。'
+          },
+          {
+            name: '横田地域DXラボ',
+            category: 'キャリア',
+            venue: '横田イノベーションルーム',
+            schedule: '隔週火曜 19:00-21:00',
+            description: '地域事業者のデジタル化を支援する実践講座。データ活用やSNS運用をワークショップ形式で学びます。'
           }
         ]
       },
@@ -686,6 +735,13 @@
             venue: '二条温泉 休憩ラウンジ',
             schedule: '毎週日曜 18:00-19:30',
             description: '温泉入浴とセットで楽しむリラクゼーションヨガ。週末の疲れを癒したい人に人気です。'
+          },
+          {
+            name: '二条ナイトクラフト',
+            category: 'アート',
+            venue: '二条町古民家アトリエ',
+            schedule: '毎週金曜 19:30-21:00',
+            description: '木工や染色など地域素材を使ったクラフト講座。仕事帰りに創作を楽しめます。'
           }
         ]
       },
@@ -720,6 +776,13 @@
             venue: '七尾港カフェ',
             schedule: '毎月第4土曜 15:00-17:00',
             description: '自家焙煎コーヒーの淹れ方とフードペアリングを学ぶ少人数講座。テイスティング体験付き。'
+          },
+          {
+            name: '七尾ナイトSUPフィット',
+            category: 'ウェルネス',
+            venue: '七尾海岸特設エリア',
+            schedule: '夏季限定 金曜 19:00-20:30',
+            description: 'ライトアップされた海で行うSUPフィットネス。バランス感覚と体幹を鍛えます。'
           }
         ]
       },
@@ -754,6 +817,13 @@
             venue: '鎌手海岸特設エリア',
             schedule: '毎週土曜 7:00-8:00',
             description: '砂浜でのサーキットトレーニング。自然の抵抗を活かした全身エクササイズです。'
+          },
+          {
+            name: '鎌手ナイトクルージングセミナー',
+            category: 'ライフスタイル',
+            venue: '鎌手漁港 遊覧船デッキ',
+            schedule: '夏季限定 土曜 19:00-20:30',
+            description: 'ナイトクルーズを楽しみながら海の環境と星空観察を学ぶ体験型セミナーです。'
           }
         ]
       },
@@ -788,6 +858,13 @@
             venue: '匹見薬草園',
             schedule: '毎月第1土曜 10:00-12:00',
             description: '薬草の育て方とセルフケアに活かす方法を学ぶ講座。ハーブティーの試飲付きです。'
+          },
+          {
+            name: '匹見里山クラフトビレッジ',
+            category: 'クラフト',
+            venue: '匹見木工房 里山工房棟',
+            schedule: '毎月第3土曜 13:00-16:00',
+            description: '地元材を活かした家具小物づくりと伝統技法を学ぶワークショップ。'
           }
         ]
       },
@@ -822,6 +899,13 @@
             venue: '美都温泉 多目的室',
             schedule: '毎週火曜 19:30-20:30',
             description: '温泉入浴とセットでリラックスできる夜ヨガ。ストレスケアと睡眠の質向上をサポートします。'
+          },
+          {
+            name: '美都里山サウナクラブ',
+            category: 'ウェルネス',
+            venue: '美都里山サウナハウス',
+            schedule: '第2・第4土曜 18:00-20:00',
+            description: '地域材で造られたテントサウナでととのう大人のリトリート。呼吸法とセルフケア講座付き。'
           }
         ]
       },
@@ -856,6 +940,13 @@
             venue: '都茂木工房',
             schedule: '毎週土曜 14:00-16:30',
             description: '家具職人が指導する木工ワークショップ。暮らしの小物から家具づくりまで挑戦できます。'
+          },
+          {
+            name: '都茂星空ヨガリトリート',
+            category: 'ウェルネス',
+            venue: '都茂里山テラス',
+            schedule: '春・秋シーズン 土曜 19:00-20:30',
+            description: '満天の星を眺めながら行うヨガと呼吸法のセッション。星空ガイドの解説付きです。'
           }
         ]
       },
@@ -890,6 +981,13 @@
             venue: '染羽ジャズバー',
             schedule: '毎月第3金曜 20:00-22:00',
             description: 'アドリブ演奏を学びながらセッションを楽しむ夜クラス。初心者向けレクチャーも用意しています。'
+          },
+          {
+            name: '染羽夜市クリエイティブマルシェ',
+            category: 'キャリア',
+            venue: '染羽町まちなか広場',
+            schedule: '毎月第2金曜 18:00-21:00',
+            description: '地域のクリエイターが集う夜市型マルシェ。出店準備や販売戦略を学ぶワークショップを同時開催。'
           }
         ]
       },
@@ -924,6 +1022,13 @@
             venue: '久城体育館',
             schedule: '毎週月・木曜 20:00-21:00',
             description: 'サーキットトレーニングとHIITを組み合わせた集中プログラム。短時間で効果を実感できます。'
+          },
+          {
+            name: '久城ナイトコワーキングラボ',
+            category: 'キャリア',
+            venue: '久城コワーキングスペース',
+            schedule: '平日夜 18:30-21:00',
+            description: '地域事業者と共創するビジネス相談会。専門家メンタリングとICT活用講座をセットで提供します。'
           }
         ]
       },
@@ -958,6 +1063,13 @@
             venue: '昭和町駅前集合',
             schedule: '毎週日曜 7:00-9:00',
             description: '市街地と山道を走るクロストレーニングサークル。レベル別グループで安心して参加できます。'
+          },
+          {
+            name: '昭和クリエイティブスタジオナイト',
+            category: 'キャリア',
+            venue: '昭和町クリエイティブスタジオ',
+            schedule: '隔週金曜 19:00-21:30',
+            description: '動画編集とSNS配信を学ぶ実践講座。地域イベントのPR動画制作に挑戦します。'
           }
         ]
       },
@@ -992,15 +1104,16 @@
             venue: '三宅町ホリスティックルーム',
             schedule: '毎週火曜 20:00-21:00',
             description: 'マインドフルネス瞑想と呼吸法で心を整える夜のサークル。オンライン参加も可能です。'
+          },
+          {
+            name: '三宅ナイトカメラスクール',
+            category: 'アート',
+            venue: '三宅町クリエイティブハブ スタジオ',
+            schedule: '隔週水曜 19:30-21:30',
+            description: '動画撮影と編集の夜間講座。SNS向けショートムービー制作を実践的に学びます。'
           }
         ]
       }
-    };
-
-    const typeLabels = {
-      elementary: '小学校',
-      middle: '中学校',
-      high: '高校'
     };
 
     const typeOrder = {
@@ -1009,8 +1122,10 @@
       high: 2
     };
 
+    const typeKeys = Object.keys(typeOrder);
+
     const state = {
-      types: new Set(Object.keys(typeLabels)),
+      types: new Set(typeKeys),
       tags: new Set(),
       term: ''
     };
@@ -1116,17 +1231,6 @@
         });
     }
 
-    function addDetail(detailList, term, value) {
-      if (!value) return;
-      const wrapper = document.createElement('div');
-      const dt = document.createElement('dt');
-      dt.textContent = term;
-      const dd = document.createElement('dd');
-      dd.textContent = value;
-      wrapper.append(dt, dd);
-      detailList.appendChild(wrapper);
-    }
-
     function createProgramMetaItem(term, value) {
       if (!value) return null;
       const li = document.createElement('li');
@@ -1207,7 +1311,7 @@
       if (results.length === 0) {
         const empty = document.createElement('p');
         empty.className = 'empty-state';
-        empty.textContent = '該当する学校が見つかりませんでした。検索条件を見直してください。';
+        empty.textContent = '該当する周辺スクール情報が見つかりませんでした。検索条件を見直してください。';
         schoolList.appendChild(empty);
       } else {
         results.forEach((school) => {
@@ -1216,66 +1320,36 @@
           article.setAttribute('role', 'listitem');
           article.dataset.type = school.type;
 
-          const header = document.createElement('header');
-          const typeEl = document.createElement('p');
-          typeEl.className = 'school-type';
-          typeEl.textContent = typeLabels[school.type];
-          const nameEl = document.createElement('h3');
-          nameEl.textContent = school.name;
-          header.append(typeEl, nameEl);
+          const nearbySection = document.createElement('div');
+          nearbySection.className = 'nearby-section';
 
-          const areaEl = document.createElement('p');
-          areaEl.className = 'school-area';
-          areaEl.textContent = school.area;
+          const nearbyHeading = document.createElement('h4');
+          nearbyHeading.textContent = `${school.area}の周辺スクール情報`;
+          nearbySection.appendChild(nearbyHeading);
 
-          const detailList = document.createElement('dl');
-          detailList.className = 'school-detail';
-          addDetail(detailList, '所在地', school.address);
-          addDetail(detailList, '特徴', school.notes);
-          addDetail(detailList, '取り組み', school.programs);
-
-          const tagContainer = document.createElement('ul');
-          tagContainer.className = 'school-tags';
-          school.tags.forEach((tag) => {
-            const li = document.createElement('li');
-            li.textContent = tag;
-            tagContainer.appendChild(li);
-          });
-
-          article.append(header, areaEl, detailList, tagContainer);
-
+          const nearbyGroups = document.createElement('div');
+          nearbyGroups.className = 'nearby-groups';
           const nearbyData = NEARBY_PROGRAMS[school.area];
-          if (nearbyData) {
-            const nearbySection = document.createElement('div');
-            nearbySection.className = 'nearby-section';
+          nearbyGroups.append(
+            createProgramList('子ども向けスクール', nearbyData && nearbyData.kids, 'kids'),
+            createProgramList('大人向けスクール', nearbyData && nearbyData.adults, 'adults')
+          );
 
-            const nearbyHeading = document.createElement('h4');
-            nearbyHeading.textContent = '周辺スクール情報';
-            nearbySection.appendChild(nearbyHeading);
-
-            const nearbyGroups = document.createElement('div');
-            nearbyGroups.className = 'nearby-groups';
-            nearbyGroups.append(
-              createProgramList('子ども向けスクール', nearbyData.kids, 'kids'),
-              createProgramList('大人向けスクール', nearbyData.adults, 'adults')
-            );
-
-            nearbySection.appendChild(nearbyGroups);
-            article.appendChild(nearbySection);
-          }
-
+          nearbySection.appendChild(nearbyGroups);
+          article.appendChild(nearbySection);
           schoolList.appendChild(article);
         });
       }
 
-      const total = SCHOOLS.length;
-      const counts = Object.fromEntries(
-        Object.keys(typeLabels).map((type) => [type, results.filter((school) => school.type === type).length])
-      );
-      const summaryParts = Object.keys(typeLabels)
-        .map((type) => `${typeLabels[type]} ${counts[type]}校`)
-        .join(' / ');
-      resultSummary.innerHTML = `<strong>${results.length}校</strong> ヒット / 登録 ${total}校<br><span class="result-breakdown">${summaryParts}</span>`;
+      const programCount = results.reduce((total, school) => {
+        const nearbyData = NEARBY_PROGRAMS[school.area];
+        if (!nearbyData) return total;
+        const kids = Array.isArray(nearbyData.kids) ? nearbyData.kids.length : 0;
+        const adults = Array.isArray(nearbyData.adults) ? nearbyData.adults.length : 0;
+        return total + kids + adults;
+      }, 0);
+
+      resultSummary.innerHTML = `<strong>${programCount}</strong> 件の周辺スクール情報を表示中<br><span class="result-breakdown">対象エリア ${results.length}件</span>`;
       resultsRegion.setAttribute('aria-busy', 'false');
     }
 


### PR DESCRIPTION
## Summary
- restrict each school tag list to its name and「ICT活用」so tag filters focus on individual校区
- change the results renderer to show only nearby program information by area when tags are selected
- enrich every周辺エリアの大人向けスクール情報 with additional listings

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4c47c94c483249f745e582153646d