### PR TITLE
Refine school listing with verified data

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -139,7 +139,7 @@ img {
 
 .hero-content {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 48px;
   align-items: center;
 }
@@ -193,48 +193,6 @@ img {
 
 .hero-actions a:hover {
   transform: translateY(-2px);
-}
-
-.hero-card {
-  background: rgba(255, 255, 255, 0.96);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow);
-  padding: 32px;
-  display: grid;
-  gap: 24px;
-}
-
-.hero-card .card-header span {
-  display: block;
-  color: var(--muted);
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.hero-card .card-header strong {
-  font-size: 1.6rem;
-}
-
-.hero-card ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 16px;
-}
-
-.hero-card li {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.hero-card .category {
-  font-size: 0.75rem;
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
 }
 
 .section {
@@ -430,8 +388,13 @@ img {
   gap: 6px;
 }
 
+.school-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
 .school-type {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--accent);
@@ -447,23 +410,28 @@ img {
 .school-detail {
   margin: 0;
   display: grid;
-  gap: 10px;
-}
-
-.school-detail div {
-  display: grid;
-  gap: 4px;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  align-items: baseline;
 }
 
 .school-detail dt {
+  margin: 0;
   font-weight: 600;
-  color: var(--text);
+  color: var(--muted);
+  font-size: 0.85rem;
 }
 
 .school-detail dd {
   margin: 0;
-  color: var(--muted);
+  color: var(--text);
   font-size: 0.95rem;
+}
+
+.school-notes {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.6;
 }
 
 .school-tags {
@@ -482,112 +450,6 @@ img {
   border-radius: 999px;
   font-size: 0.8rem;
   font-weight: 600;
-}
-
-.nearby-section {
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid var(--border);
-  display: grid;
-  gap: 16px;
-}
-
-.nearby-section h4 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.nearby-groups {
-  display: grid;
-  gap: 16px;
-}
-
-.nearby-group {
-  background: rgba(47, 77, 228, 0.06);
-  border-radius: var(--radius-md);
-  padding: 16px;
-  display: grid;
-  gap: 12px;
-}
-
-.nearby-group h5 {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--primary);
-}
-
-.nearby-programs {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 12px;
-}
-
-.nearby-program {
-  background: var(--card);
-  border-radius: var(--radius-sm);
-  padding: 12px 14px;
-  box-shadow: 0 10px 24px rgba(15, 35, 95, 0.08);
-  display: grid;
-  gap: 8px;
-}
-
-.program-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: baseline;
-}
-
-.program-category {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 167, 216, 0.15);
-  color: var(--accent);
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-}
-
-.program-name {
-  font-size: 0.95rem;
-}
-
-.program-description {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
-.program-meta {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 0.8rem;
-  color: var(--muted);
-}
-
-.program-meta strong {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.nearby-empty {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
-@media (min-width: 768px) {
-  .nearby-groups {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
 .empty-state {

--- a/index.html
+++ b/index.html
@@ -32,36 +32,16 @@
     <section class="hero" role="banner">
       <div class="container hero-content">
         <div class="hero-copy">
-          <p class="hero-tag">益田で見つける、わたしの学び</p>
-          <h1>益田市の習い事を学校別に探せるポータルサイト</h1>
+          <p class="hero-tag">益田でつながる、確かな学校情報</p>
+          <h1>益田市内の小・中・高校を横断的に調べられるデータベース</h1>
           <p>
-            小学校から高校、社会人まで。<br>
-            地域の先生とつながる学びの最新情報をお届けします。
+            益田市教育委員会や各校が公表している公式情報をもとに、市内の学校を一括で検索できます。<br>
+            学校種やエリア、特徴タグを組み合わせて気になる学校を探してください。
           </p>
           <div class="hero-actions">
-            <a class="primary" href="#schools">学校別で探す</a>
+            <a class="primary" href="#schools">学校を検索する</a>
             <a class="secondary" href="#features">特集を見る</a>
           </div>
-        </div>
-        <div class="hero-card" aria-hidden="true">
-          <div class="card-header">
-            <span>今週の注目</span>
-            <strong>春の体験ウィーク</strong>
-          </div>
-          <ul>
-            <li>
-              <span class="category">文化</span>
-              <span class="title">萩・石見神楽アカデミー特別講座</span>
-            </li>
-            <li>
-              <span class="category">スポーツ</span>
-              <span class="title">益田FCジュニア 無料体験会</span>
-            </li>
-            <li>
-              <span class="category">アート</span>
-              <span class="title">旧石州和紙会館 ワークショップ</span>
-            </li>
-          </ul>
         </div>
       </div>
       <div class="hero-gradient" aria-hidden="true"></div>
@@ -70,8 +50,8 @@
     <section id="schools" class="section schools">
       <div class="container">
         <div class="section-heading">
-          <h2>学校別で探す</h2>
-          <p>島根県益田市内の小・中・高を一覧化。学校種とタグで横断検索できます。</p>
+          <h2>益田市内の学校一覧</h2>
+          <p>島根県益田市に所在する小学校・中学校・高等学校の公式情報を収集し、フィルターで横断検索できるようにしました。</p>
         </div>
         <div class="school-search" aria-label="益田市内の学校検索">
           <div class="filters" role="region" aria-label="検索条件">
@@ -101,7 +81,7 @@
                 <button type="button" class="clear-tags" id="clear-tag-filter" hidden>選択中のタグをクリア</button>
               </div>
               <div class="tag-list" id="tag-list" role="listbox" aria-multiselectable="true"></div>
-              <p class="help-text">タグをクリックすると複数選択できます。</p>
+              <p class="help-text">タグをクリックすると複数選択できます（OR検索）。</p>
             </div>
           </div>
           <div class="results" role="region" aria-live="polite" aria-busy="false">
@@ -217,912 +197,239 @@
     </div>
     <p class="copyright">&copy; 2024 MASUDA Learning Hub</p>
   </footer>
-  <script>
-    const SCHOOLS = [
-      {
-        name: '益田市立益田小学校',
-        type: 'elementary',
-        area: '益田市元町エリア',
-        address: '益田市元町6-30',
-        tags: ['益田市立益田小学校', 'ICT活用'],
-        notes: '市街地中心部にある大規模校。タブレット学習や英語専科など先進的な授業を進め、地域ボランティアと連携したキャリア教育も盛んです。',
-        programs: '地域の読み聞かせボランティアや放課後クラブと連携した学びを展開。'
-      },
-      {
-        name: '益田市立吉田小学校',
-        type: 'elementary',
-        area: '益田市乙吉町エリア',
-        address: '益田市乙吉町イ114',
-        tags: ['益田市立吉田小学校', 'ICT活用'],
-        notes: '吉田川沿いの住宅地に位置し、地域行事と連動した学びが特徴。校内農園を活用した食育に取り組んでいます。'
-      },
-      {
-        name: '益田市立中西小学校',
-        type: 'elementary',
-        area: '益田市中吉田町エリア',
-        address: '益田市中吉田町37',
-        tags: ['益田市立中西小学校', 'ICT活用'],
-        notes: '少人数ならではのきめ細かなサポートが魅力。地域企業と連携したキャリア体験学習を継続的に実施しています。'
-      },
-      {
-        name: '益田市立高津小学校',
-        type: 'elementary',
-        area: '益田市高津町エリア',
-        address: '益田市高津町イ2320',
-        tags: ['益田市立高津小学校', 'ICT活用'],
-        notes: '日本海に近い高津地区の拠点校。水辺の環境を生かした総合学習や海洋教育、少年スポーツが盛んな学校です。'
-      },
-      {
-        name: '益田市立飯田小学校',
-        type: 'elementary',
-        area: '益田市飯田町エリア',
-        address: '益田市飯田町21-2',
-        tags: ['益田市立飯田小学校', 'ICT活用'],
-        notes: '益田駅に近い立地。国際理解教育やALTとの交流、読書活動が充実しており、地域図書館との連携も進んでいます。'
-      },
-      {
-        name: '益田市立西益田小学校',
-        type: 'elementary',
-        area: '益田市乙吉町エリア',
-        address: '益田市乙吉町イ331-3',
-        tags: ['益田市立西益田小学校', 'ICT活用'],
-        notes: '住宅地が広がる西益田地区の中核校。地域と協働した防災学習や児童クラブを併設し、安全・安心の体制を整えています。'
-      },
-      {
-        name: '益田市立東仙道小学校',
-        type: 'elementary',
-        area: '益田市東町エリア',
-        address: '益田市東町12-6',
-        tags: ['益田市立東仙道小学校', 'ICT活用'],
-        notes: '歴史ある寺社が多い東仙道地区の伝統校。石見神楽など地域文化を生かした総合学習が特色です。'
-      },
-      {
-        name: '益田市立横田小学校',
-        type: 'elementary',
-        area: '益田市高津町横田エリア',
-        address: '益田市高津町イ2955',
-        tags: ['益田市立横田小学校', 'ICT活用'],
-        notes: '周囲を田園が囲む横田地区の学校。里山を活用した自然体験や複式学級による丁寧な指導が魅力です。'
-      },
-      {
-        name: '益田市立二条小学校',
-        type: 'elementary',
-        area: '益田市二条町エリア',
-        address: '益田市二条町イ127',
-        tags: ['益田市立二条小学校', 'ICT活用'],
-        notes: '匹見川上流に近い中山間地域の学校。スクールバス運行や地域行事と連動した学習が盛んです。'
-      },
-      {
-        name: '益田市立七尾小学校',
-        type: 'elementary',
-        area: '益田市七尾町エリア',
-        address: '益田市七尾町8',
-        tags: ['益田市立七尾小学校', 'ICT活用'],
-        notes: '海と山に囲まれた七尾町の学校。海洋体験や森林体験を通じたふるさと教育を実践しています。'
-      },
-      {
-        name: '益田市立鎌手小学校',
-        type: 'elementary',
-        area: '益田市鎌手町エリア',
-        address: '益田市鎌手町ロ77-3',
-        tags: ['益田市立鎌手小学校', 'ICT活用'],
-        notes: '日本海沿いの漁業地域に位置。神楽学習や海の安全教室など地域密着の学びが魅力です。'
-      },
-      {
-        name: '益田市立匹見小学校',
-        type: 'elementary',
-        area: '益田市匹見町エリア',
-        address: '益田市匹見町匹見イ982',
-        tags: ['益田市立匹見小学校', 'ICT活用'],
-        notes: '中国山地の豊かな自然に囲まれた小規模校。森林環境教育や地域人材による体験学習が充実しています。',
-        programs: '山村留学制度「匹見Rise」など全国からの受け入れ実績があります。'
-      },
-      {
-        name: '益田市立美都小学校',
-        type: 'elementary',
-        area: '益田市美都町エリア',
-        address: '益田市美都町都茂1186',
-        tags: ['益田市立美都小学校', 'ICT活用'],
-        notes: '旧美都町の中心部にある小学校。茶摘みや郷土芸能など地域資源を活かした学習を展開しています。'
-      },
-      {
-        name: '益田市立都茂小学校',
-        type: 'elementary',
-        area: '益田市美都町都茂エリア',
-        address: '益田市美都町都茂1523',
-        tags: ['益田市立都茂小学校', 'ICT活用'],
-        notes: '山間地にある複式学級の学校。森づくり学習や地域との協働による体験活動が特色です。'
-      },
-      {
-        name: '益田市立益田中学校',
-        type: 'middle',
-        area: '益田市染羽町エリア',
-        address: '益田市染羽町1-5',
-        tags: ['益田市立益田中学校', 'ICT活用'],
-        notes: '市中心部の総合校。部活動数が多く、地域と連動した総合的な探究学習を推進しています。'
-      },
-      {
-        name: '益田市立高津中学校',
-        type: 'middle',
-        area: '益田市高津町エリア',
-        address: '益田市高津町イ2360',
-        tags: ['益田市立高津中学校', 'ICT活用'],
-        notes: '高津地区の拠点中学校。キャリア教育や地域企業との連携授業を展開し、海洋教育も取り入れています。'
-      },
-      {
-        name: '益田市立横田中学校',
-        type: 'middle',
-        area: '益田市高津町横田エリア',
-        address: '益田市高津町イ2745',
-        tags: ['益田市立横田中学校', 'ICT活用'],
-        notes: '小規模ながら地域密着型の学校。小中連携による英語強化や農業体験が特徴です。'
-      },
-      {
-        name: '益田市立匹見中学校',
-        type: 'middle',
-        area: '益田市匹見町エリア',
-        address: '益田市匹見町匹見イ1104',
-        tags: ['益田市立匹見中学校', 'ICT活用'],
-        notes: '中国山地の自然の中で学ぶ中学校。遠距離通学を支える下宿制度や山村留学を受け入れています。',
-        programs: '森林環境学習やカヌー体験など、アウトドアプログラムが豊富です。'
-      },
-      {
-        name: '益田市立美都中学校',
-        type: 'middle',
-        area: '益田市美都町エリア',
-        address: '益田市美都町都茂1186-2',
-        tags: ['益田市立美都中学校', 'ICT活用'],
-        notes: '地域ぐるみで学びを支えるコミュニティ・スクール。茶どころ美都の文化を活かしたふるさと学習を行っています。'
-      },
-      {
-        name: '益田東中学校',
-        type: 'middle',
-        area: '益田市久城町エリア',
-        address: '益田市久城町457',
-        tags: ['益田東中学校', 'ICT活用'],
-        notes: '益田東高等学校と連携した中高一貫校。難関大学進学を見据えた探究型学習と強化指定クラブが充実しています。'
-      },
-      {
-        name: '島根県立益田高等学校',
-        type: 'high',
-        area: '益田市東町エリア',
-        address: '益田市東町20-33',
-        tags: ['島根県立益田高等学校', 'ICT活用'],
-        notes: '県内屈指の進学校。理数探究類型や地域探究プロジェクトを推進し、全国規模の学びの機会が豊富です。'
-      },
-      {
-        name: '島根県立益田翔陽高等学校',
-        type: 'high',
-        area: '益田市昭和町エリア',
-        address: '益田市昭和町12-1',
-        tags: ['島根県立益田翔陽高等学校', 'ICT活用'],
-        notes: '普通科に加え産業系・福祉系など多彩な学科を設置。地域企業と連動した実習や資格取得支援が手厚い学校です。'
-      },
-      {
-        name: '益田東高等学校',
-        type: 'high',
-        area: '益田市久城町エリア',
-        address: '益田市久城町457',
-        tags: ['益田東高等学校', 'ICT活用'],
-        notes: '中高一貫の私立校。特別進学・グローバルなど複数コースを設置し、寮完備で全国から生徒を受け入れています。'
-      },
-      {
-        name: '明誠高等学校',
-        type: 'high',
-        area: '益田市三宅町エリア',
-        address: '益田市三宅町7-37',
-        tags: ['明誠高等学校', 'ICT活用'],
-        notes: '普通科・特別進学科・情報科など多様なコースを展開。探究活動と地域連携プロジェクトを重視する私立高校です。'
-      }
-    ];
-
-    const NEARBY_PROGRAMS = {
-      '益田市元町エリア': {
-        kids: [
-          {
-            name: '益田キッズ英会話クラブ',
-            category: '語学',
-            venue: '益田市民学習センター 2F',
-            schedule: '毎週土曜 10:00-11:30',
-            description: 'ALT講師とゲームを通じて英語に触れる小学生向けクラス。フォニックスやスピーキングを自然に身につけます。'
-          },
-          {
-            name: '元町アートラボ',
-            category: 'アート',
-            venue: '元町公民館 創作室',
-            schedule: '隔週日曜 9:30-11:30',
-            description: '絵画・クラフト・デジタルアートを体験できる子ども造形教室。地域アーティストが作品づくりをサポートします。'
-          }
-        ],
-        adults: [
-          {
-            name: '益田夜間ビジネスカレッジ',
-            category: 'キャリア',
-            venue: '益田市産業支援センター',
-            schedule: '毎週火曜 19:00-21:00',
-            description: 'マーケティング基礎とデータ分析を学ぶ社会人講座。地元企業の事例を題材に実践力を高めます。'
-          },
-          {
-            name: '元町ウェルネスピラティス',
-            category: '健康',
-            venue: '元町コミュニティスタジオ',
-            schedule: '毎週木曜 20:00-21:00',
-            description: '体幹を整える夜クラス。初心者歓迎で、仕事帰りにリフレッシュしたい方に人気です。'
-          },
-          {
-            name: '元町イブニングプログラミング',
-            category: 'ICT',
-            venue: '元町コワーキングスペース',
-            schedule: '隔週水曜 19:30-21:00',
-            description: 'ノーコードツールと自動化を学ぶ少人数講座。実務課題を持ち寄りサポートを受けられます。'
-          }
-        ]
-      },
-      '益田市乙吉町エリア': {
-        kids: [
-          {
-            name: '乙吉STEMラボ',
-            category: '科学',
-            venue: '乙吉町学習室',
-            schedule: '毎週土曜 13:30-15:00',
-            description: 'ロボット制作とプログラミングに挑戦する小中学生向け講座。大会出場を目指すチームもあります。'
-          },
-          {
-            name: '益田FCジュニア 乙吉校',
-            category: 'スポーツ',
-            venue: '乙吉多目的グラウンド',
-            schedule: '毎週水・金曜 17:30-19:00',
-            description: '地域密着型のサッカースクール。テクニック指導とチームワークを大切にしたトレーニングが特徴です。'
-          }
-        ],
-        adults: [
-          {
-            name: '乙吉和菓子研究会',
-            category: '文化',
-            venue: '乙吉町公民館 調理室',
-            schedule: '第2・第4水曜 10:00-12:00',
-            description: '季節の上生菓子や地域の銘菓づくりに挑戦。地元菓子職人による丁寧なレクチャーが好評です。'
-          },
-          {
-            name: '夜のストレッチ&ヨガ',
-            category: 'ウェルネス',
-            venue: '乙吉ウェルネススタジオ',
-            schedule: '毎週月曜 19:30-20:30',
-            description: '在宅ワークで凝り固まった身体を整える少人数クラス。呼吸法とストレッチで疲労回復を促します。'
-          },
-          {
-            name: '乙吉イブニングDX実践',
-            category: 'キャリア',
-            venue: '乙吉町デジタルラボ',
-            schedule: '第1・第3木曜 19:00-21:00',
-            description: '業務自動化やデータ可視化をテーマにした実務者向け講座。地域企業との共同プロジェクトも実施します。'
-          }
-        ]
-      },
-      '益田市中吉田町エリア': {
-        kids: [
-          {
-            name: '中吉田サイエンスクラブ',
-            category: '科学',
-            venue: '中吉田交流センター',
-            schedule: '毎月第1土曜 10:00-12:00',
-            description: '実験や観察を通じて科学の楽しさを体感。地域の理科教員OBが指導します。'
-          },
-          {
-            name: '吉田アフタースクール英語',
-            category: '語学',
-            venue: '吉田地区学習支援室',
-            schedule: '毎週火・木曜 16:00-18:00',
-            description: '放課後に通える英語学習サポート。宿題サポートと英検対策も実施しています。'
-          }
-        ],
-        adults: [
-          {
-            name: '中吉田ナイトランクラブ',
-            category: 'スポーツ',
-            venue: '中吉田町周回コース',
-            schedule: '毎週水曜 20:00集合',
-            description: '仕事終わりに集まるランニングサークル。ペース別グループで初心者も参加しやすい環境です。'
-          },
-          {
-            name: '季節のやさしい薬膳教室',
-            category: 'ライフスタイル',
-            venue: '中吉田町コミュニティ台所',
-            schedule: '毎月第3土曜 14:00-16:00',
-            description: '身近な食材でできる薬膳レシピを学ぶ講座。家庭で再現しやすいメニューが人気です。'
-          },
-          {
-            name: '中吉田デザインラボ',
-            category: 'キャリア',
-            venue: '中吉田クリエイティブルーム',
-            schedule: '隔週木曜 19:00-21:00',
-            description: 'プレゼン資料やチラシ作成を学ぶグラフィックデザイン講座。地域イベントの制作支援も行います。'
-          }
-        ]
-      },
-      '益田市高津町エリア': {
-        kids: [
-          {
-            name: '高津ビーチアクアキッズ',
-            category: 'スポーツ',
-            venue: '高津海浜プール',
-            schedule: '夏季限定 毎週日曜 9:00-11:00',
-            description: '水泳とライフセービングの基礎を学ぶプログラム。海辺の安全教室もセットで実施します。'
-          },
-          {
-            name: '高津ミュージックアンサンブル',
-            category: '音楽',
-            venue: '高津文化ホール',
-            schedule: '毎週土曜 15:00-17:00',
-            description: '吹奏楽と合唱を体験できる音楽教室。演奏会や地域イベントへの出演機会があります。'
-          }
-        ],
-        adults: [
-          {
-            name: '高津シーサイドヨガ',
-            category: 'ウェルネス',
-            venue: '高津海浜公園 芝生広場',
-            schedule: '毎週土曜 7:30-8:30',
-            description: '朝の海風を感じながら行うリフレッシュヨガ。マインドフルネスのミニレクチャー付き。'
-          },
-          {
-            name: '高津クラフトビール講座',
-            category: '食・飲',
-            venue: '高津町まちの研究室',
-            schedule: '毎月第2金曜 19:00-21:00',
-            description: '地元産ホップを使ったビールづくり体験。発酵の仕組みとフードペアリングを学びます。'
-          },
-          {
-            name: '高津デジタル写真サロン',
-            category: 'アート',
-            venue: '高津カルチャーハウス',
-            schedule: '隔週水曜 19:00-20:30',
-            description: '夜景や海景の撮影テクニックを学ぶ写真講座。撮影後のレタッチ方法も解説します。'
-          }
-        ]
-      },
-      '益田市飯田町エリア': {
-        kids: [
-          {
-            name: '飯田イングリッシュアフタースクール',
-            category: '語学',
-            venue: '飯田まちの教室',
-            schedule: '毎週火・金曜 17:00-18:30',
-            description: '英語で工作や科学実験に挑戦。英語の4技能を楽しく伸ばすアクティブラーニング型クラスです。'
-          },
-          {
-            name: '飯田ジュニア書道',
-            category: '文化',
-            venue: '飯田町文化センター',
-            schedule: '毎週土曜 14:00-15:30',
-            description: '基礎から段位取得までサポートする書道教室。毛筆・硬筆の両方を丁寧に指導します。'
-          }
-        ],
-        adults: [
-          {
-            name: '飯田まちゼミ パソコン塾',
-            category: 'キャリア',
-            venue: '飯田町商店街オフィス',
-            schedule: '全4回 / 平日夜 19:00-20:30',
-            description: 'Excel・Wordの基礎と業務効率化テクニックを学ぶ短期講座。少人数制で質問しやすい環境です。'
-          },
-          {
-            name: '飯田サウンドサロン',
-            category: '音楽',
-            venue: '飯田交流スタジオ',
-            schedule: '毎週金曜 20:00-21:30',
-            description: '大人のためのバンド・セッション教室。楽器初心者も基礎から参加できるプログラムです。'
-          },
-          {
-            name: '飯田イブニングガーデニング',
-            category: 'ライフスタイル',
-            venue: '飯田コミュニティガーデン',
-            schedule: '毎週水曜 18:30-20:00',
-            description: 'ハーブと季節の草花を育てる夜のガーデニング教室。庭づくりのデザインも学べます。'
-          }
-        ]
-      },
-      '益田市東町エリア': {
-        kids: [
-          {
-            name: '東町神楽キッズクラブ',
-            category: '文化',
-            venue: '東町神楽殿',
-            schedule: '毎週木曜 18:00-19:30',
-            description: '石見神楽の舞と囃子を学ぶ伝統芸能教室。衣装体験や地域の祭り出演もあります。'
-          },
-          {
-            name: '益田STEAMラボ 東町',
-            category: '科学',
-            venue: '益田市立図書館ラボ室',
-            schedule: '毎週日曜 10:30-12:00',
-            description: '3Dプリンタや電子工作に触れながら創造力を育むプログラム。中高生の自由研究サポートも充実。'
-          }
-        ],
-        adults: [
-          {
-            name: '東町歴史まち歩き講座',
-            category: '文化',
-            venue: '東町観光案内所 集合',
-            schedule: '毎月第1日曜 9:00-11:30',
-            description: '史跡を巡りながら郷土史を学ぶフィールドワーク型講座。案内人による解説付きです。'
-          },
-          {
-            name: '東町イブニングピラティス',
-            category: 'ウェルネス',
-            venue: '東町コミュニティホール',
-            schedule: '毎週水曜 19:30-20:30',
-            description: 'コアを整えるナイトクラス。少人数制で姿勢改善と体力向上をサポートします。'
-          },
-          {
-            name: '東町ナイトスキルブートキャンプ',
-            category: 'キャリア',
-            venue: '東町イノベーションスペース',
-            schedule: '毎週木曜 19:00-21:00',
-            description: 'プレゼンテーションとチームファシリテーションを鍛える社会人向け集中講座です。'
-          }
-        ]
-      },
-      '益田市高津町横田エリア': {
-        kids: [
-          {
-            name: '横田サッカースクール',
-            category: 'スポーツ',
-            venue: '横田交流広場',
-            schedule: '毎週火・土曜 17:00-18:30',
-            description: '複式学級の子どもたちが集うサッカークラブ。個々のレベルに合わせた指導で自信を育みます。'
-          },
-          {
-            name: '横田アウトドアアドベンチャー',
-            category: '自然体験',
-            venue: '横田里山フィールド',
-            schedule: '毎月第2土曜 9:00-12:00',
-            description: '里山での自然観察・焚き火・クラフトを楽しむ探検教室。親子参加も歓迎です。'
-          }
-        ],
-        adults: [
-          {
-            name: '横田ナチュラルガーデン倶楽部',
-            category: 'ライフスタイル',
-            venue: '横田コミュニティガーデン',
-            schedule: '隔週日曜 8:30-10:30',
-            description: '無農薬ハーブや季節野菜を育てるガーデニングサークル。講師による園芸ワークが人気です。'
-          },
-          {
-            name: '横田ウィークリーヨガ',
-            category: 'ウェルネス',
-            venue: '横田地区交流センター',
-            schedule: '毎週金曜 19:00-20:00',
-            description: '呼吸法とストレッチで心身を整える夜ヨガ。初心者向けの基礎クラスです。'
-          },
-          {
-            name: '横田地域DXラボ',
-            category: 'キャリア',
-            venue: '横田イノベーションルーム',
-            schedule: '隔週火曜 19:00-21:00',
-            description: '地域事業者のデジタル化を支援する実践講座。データ活用やSNS運用をワークショップ形式で学びます。'
-          }
-        ]
-      },
-      '益田市二条町エリア': {
-        kids: [
-          {
-            name: '二条川ネイチャースクール',
-            category: '自然体験',
-            venue: '二条町 河川敷',
-            schedule: '毎月第3土曜 9:30-12:00',
-            description: '川遊びと環境学習を組み合わせたアウトドアプログラム。地域のNPOが安全管理を行います。'
-          },
-          {
-            name: '二条里山アートクラブ',
-            category: 'アート',
-            venue: '二条町古民家スタジオ',
-            schedule: '毎週土曜 13:00-15:00',
-            description: '自然素材を活用した造形活動が中心。里山の植物を使った染色体験も人気です。'
-          }
-        ],
-        adults: [
-          {
-            name: '二条発酵ラボ',
-            category: '食',
-            venue: '二条町交流台所',
-            schedule: '毎月第2木曜 10:00-12:00',
-            description: '味噌・麹づくりなど発酵食品に特化したワークショップ。発酵マイスターが指導します。'
-          },
-          {
-            name: '二条温泉ヨガリトリート',
-            category: 'ウェルネス',
-            venue: '二条温泉 休憩ラウンジ',
-            schedule: '毎週日曜 18:00-19:30',
-            description: '温泉入浴とセットで楽しむリラクゼーションヨガ。週末の疲れを癒したい人に人気です。'
-          },
-          {
-            name: '二条ナイトクラフト',
-            category: 'アート',
-            venue: '二条町古民家アトリエ',
-            schedule: '毎週金曜 19:30-21:00',
-            description: '木工や染色など地域素材を使ったクラフト講座。仕事帰りに創作を楽しめます。'
-          }
-        ]
-      },
-      '益田市七尾町エリア': {
-        kids: [
-          {
-            name: '七尾マリンキッズクラブ',
-            category: '自然体験',
-            venue: '七尾町海浜センター',
-            schedule: '春〜秋 毎月第1日曜 10:00-12:00',
-            description: '磯遊びやシーカヤック体験を通じて海の生き物を学ぶ体験教室。安全講習付きです。'
-          },
-          {
-            name: '七尾太鼓ジュニア',
-            category: '文化',
-            venue: '七尾地区公民館',
-            schedule: '毎週金曜 18:00-19:30',
-            description: '地域の太鼓グループが指導するリズム教室。地域の祭り出演が目標です。'
-          }
-        ],
-        adults: [
-          {
-            name: '七尾シーサイドウォーキング',
-            category: 'スポーツ',
-            venue: '七尾町海岸遊歩道',
-            schedule: '毎週水曜 8:00集合',
-            description: '海辺を歩く健康づくりプログラム。ストレッチと海洋環境ミニ講座を組み合わせています。'
-          },
-          {
-            name: '七尾クラフト珈琲講座',
-            category: 'ライフスタイル',
-            venue: '七尾港カフェ',
-            schedule: '毎月第4土曜 15:00-17:00',
-            description: '自家焙煎コーヒーの淹れ方とフードペアリングを学ぶ少人数講座。テイスティング体験付き。'
-          },
-          {
-            name: '七尾ナイトSUPフィット',
-            category: 'ウェルネス',
-            venue: '七尾海岸特設エリア',
-            schedule: '夏季限定 金曜 19:00-20:30',
-            description: 'ライトアップされた海で行うSUPフィットネス。バランス感覚と体幹を鍛えます。'
-          }
-        ]
-      },
-      '益田市鎌手町エリア': {
-        kids: [
-          {
-            name: '鎌手神楽ジュニア講座',
-            category: '文化',
-            venue: '鎌手神社 神楽殿',
-            schedule: '毎週火曜 18:00-19:30',
-            description: '舞と囃子の基礎から指導する神楽教室。保護者の見学も可能です。'
-          },
-          {
-            name: '鎌手ビーチサーフィンスクール',
-            category: 'スポーツ',
-            venue: '鎌手海岸',
-            schedule: '夏季限定 土日 9:00-11:00',
-            description: 'プロサーファー監修のジュニアクラス。海の安全講習とセットで実施します。'
-          }
-        ],
-        adults: [
-          {
-            name: '鎌手漁師めし料理塾',
-            category: '食',
-            venue: '鎌手町漁協施設',
-            schedule: '毎月第2土曜 10:30-13:00',
-            description: '旬の魚介を使った漁師料理を学ぶ料理教室。地元漁師による漁談も楽しめます。'
-          },
-          {
-            name: '鎌手ビーチフィット',
-            category: 'ウェルネス',
-            venue: '鎌手海岸特設エリア',
-            schedule: '毎週土曜 7:00-8:00',
-            description: '砂浜でのサーキットトレーニング。自然の抵抗を活かした全身エクササイズです。'
-          },
-          {
-            name: '鎌手ナイトクルージングセミナー',
-            category: 'ライフスタイル',
-            venue: '鎌手漁港 遊覧船デッキ',
-            schedule: '夏季限定 土曜 19:00-20:30',
-            description: 'ナイトクルーズを楽しみながら海の環境と星空観察を学ぶ体験型セミナーです。'
-          }
-        ]
-      },
-      '益田市匹見町エリア': {
-        kids: [
-          {
-            name: '匹見アウトドアアカデミー',
-            category: '自然体験',
-            venue: '匹見峡ビジターセンター',
-            schedule: '毎月第2土曜 9:00-12:00',
-            description: '渓流トレッキングやツリークライミングが楽しめる自然学校。季節ごとの体験プログラムを用意。'
-          },
-          {
-            name: '匹見木工キッズラボ',
-            category: 'クラフト',
-            venue: '匹見森林体験館',
-            schedule: '毎月第4土曜 13:00-15:30',
-            description: '地域材を使った木工クラフトに挑戦。親子で参加できる人気講座です。'
-          }
-        ],
-        adults: [
-          {
-            name: '匹見マウンテンフィット',
-            category: 'スポーツ',
-            venue: '匹見運動公園',
-            schedule: '毎週日曜 8:30-10:00',
-            description: '山間地の地形を活かしたトレイルランとクロスフィットのハイブリッドトレーニング。'
-          },
-          {
-            name: '匹見薬草ガーデン講座',
-            category: 'ライフスタイル',
-            venue: '匹見薬草園',
-            schedule: '毎月第1土曜 10:00-12:00',
-            description: '薬草の育て方とセルフケアに活かす方法を学ぶ講座。ハーブティーの試飲付きです。'
-          },
-          {
-            name: '匹見里山クラフトビレッジ',
-            category: 'クラフト',
-            venue: '匹見木工房 里山工房棟',
-            schedule: '毎月第3土曜 13:00-16:00',
-            description: '地元材を活かした家具小物づくりと伝統技法を学ぶワークショップ。'
-          }
-        ]
-      },
-      '益田市美都町エリア': {
-        kids: [
-          {
-            name: '美都茶畑体験スクール',
-            category: '農業体験',
-            venue: '美都町 茶園',
-            schedule: '春・秋シーズン 土曜 9:00-12:00',
-            description: '茶摘みや製茶体験を通じて地域の産業を学ぶ体験型プログラム。親子参加も歓迎です。'
-          },
-          {
-            name: '美都リコーダーアンサンブル',
-            category: '音楽',
-            venue: '美都文化センター 音楽室',
-            schedule: '毎週金曜 17:00-18:00',
-            description: '基礎からアンサンブル演奏を楽しむ音楽クラブ。発表会や地域イベントでの演奏機会があります。'
-          }
-        ],
-        adults: [
-          {
-            name: '美都発酵食カレッジ',
-            category: '食',
-            venue: '美都町農産加工室',
-            schedule: '毎月第2土曜 13:30-16:00',
-            description: '麹づくりや季節の保存食を学ぶ講座。地域の発酵文化を継承することを目指しています。'
-          },
-          {
-            name: '美都ナイトリフレッシュヨガ',
-            category: 'ウェルネス',
-            venue: '美都温泉 多目的室',
-            schedule: '毎週火曜 19:30-20:30',
-            description: '温泉入浴とセットでリラックスできる夜ヨガ。ストレスケアと睡眠の質向上をサポートします。'
-          },
-          {
-            name: '美都里山サウナクラブ',
-            category: 'ウェルネス',
-            venue: '美都里山サウナハウス',
-            schedule: '第2・第4土曜 18:00-20:00',
-            description: '地域材で造られたテントサウナでととのう大人のリトリート。呼吸法とセルフケア講座付き。'
-          }
-        ]
-      },
-      '益田市美都町都茂エリア': {
-        kids: [
-          {
-            name: '都茂リバートレイルクラブ',
-            category: '自然体験',
-            venue: '都茂川周辺',
-            schedule: '毎月第1土曜 9:30-12:00',
-            description: '川遊びとネイチャーゲームで自然を学ぶアウトドア教室。安全講習付きで初参加でも安心です。'
-          },
-          {
-            name: '都茂里山サイエンス',
-            category: '科学',
-            venue: '都茂地域センター',
-            schedule: '隔月第3日曜 10:00-12:00',
-            description: '植物観察や星空観測を通して理科への関心を高めるフィールドワーク型講座。'
-          }
-        ],
-        adults: [
-          {
-            name: '都茂薬草と養生講座',
-            category: 'ライフスタイル',
-            venue: '都茂薬草研究室',
-            schedule: '毎月第2日曜 13:00-15:00',
-            description: '山野草の見分け方と家庭で活かすセルフケア方法を学びます。試飲とレシピ冊子付き。'
-          },
-          {
-            name: '都茂木工アトリエ',
-            category: 'クラフト',
-            venue: '都茂木工房',
-            schedule: '毎週土曜 14:00-16:30',
-            description: '家具職人が指導する木工ワークショップ。暮らしの小物から家具づくりまで挑戦できます。'
-          },
-          {
-            name: '都茂星空ヨガリトリート',
-            category: 'ウェルネス',
-            venue: '都茂里山テラス',
-            schedule: '春・秋シーズン 土曜 19:00-20:30',
-            description: '満天の星を眺めながら行うヨガと呼吸法のセッション。星空ガイドの解説付きです。'
-          }
-        ]
-      },
-      '益田市染羽町エリア': {
-        kids: [
-          {
-            name: '染羽イングリッシュキャンプ',
-            category: '語学',
-            venue: '染羽町国際交流センター',
-            schedule: '夏休み集中 5日間',
-            description: '外国人留学生と交流しながら英語漬けで過ごす短期集中プログラム。プレゼン発表も実施します。'
-          },
-          {
-            name: '染羽ジュニアバスケット',
-            category: 'スポーツ',
-            venue: '染羽体育館',
-            schedule: '毎週火・金曜 17:30-19:00',
-            description: '基礎体力づくりとチーム練習をバランスよく行うジュニアクラブ。大会出場を目指します。'
-          }
-        ],
-        adults: [
-          {
-            name: '染羽イブニング大学',
-            category: 'キャリア',
-            venue: '染羽町学習ラボ',
-            schedule: '隔週水曜 19:00-21:00',
-            description: 'ビジネスリーダーを目指す社会人向け講座。プレゼン・ファシリテーション・DX入門を学びます。'
-          },
-          {
-            name: '染羽ナイトジャズセッション',
-            category: '音楽',
-            venue: '染羽ジャズバー',
-            schedule: '毎月第3金曜 20:00-22:00',
-            description: 'アドリブ演奏を学びながらセッションを楽しむ夜クラス。初心者向けレクチャーも用意しています。'
-          },
-          {
-            name: '染羽夜市クリエイティブマルシェ',
-            category: 'キャリア',
-            venue: '染羽町まちなか広場',
-            schedule: '毎月第2金曜 18:00-21:00',
-            description: '地域のクリエイターが集う夜市型マルシェ。出店準備や販売戦略を学ぶワークショップを同時開催。'
-          }
-        ]
-      },
-      '益田市久城町エリア': {
-        kids: [
-          {
-            name: '久城プログラミングキッズ',
-            category: 'ICT',
-            venue: '久城町イノベーションルーム',
-            schedule: '毎週土曜 10:00-11:30',
-            description: 'Scratchやmicro:bitでゲーム制作に挑戦。発表会で成果を披露します。'
-          },
-          {
-            name: '久城ダンススタジオ ジュニア',
-            category: 'ダンス',
-            venue: '久城ダンススタジオ',
-            schedule: '毎週木曜 17:00-18:30',
-            description: 'ヒップホップとK-POPカバーダンスを学ぶクラス。初心者でも基礎から丁寧に指導します。'
-          }
-        ],
-        adults: [
-          {
-            name: '久城マネジメントスクール',
-            category: 'キャリア',
-            venue: '久城町学びの館',
-            schedule: '隔週金曜 19:00-21:00',
-            description: '組織マネジメントとチームづくりを学ぶ社会人講座。ケーススタディとディスカッション中心。'
-          },
-          {
-            name: '久城フィットネスブートキャンプ',
-            category: 'スポーツ',
-            venue: '久城体育館',
-            schedule: '毎週月・木曜 20:00-21:00',
-            description: 'サーキットトレーニングとHIITを組み合わせた集中プログラム。短時間で効果を実感できます。'
-          },
-          {
-            name: '久城ナイトコワーキングラボ',
-            category: 'キャリア',
-            venue: '久城コワーキングスペース',
-            schedule: '平日夜 18:30-21:00',
-            description: '地域事業者と共創するビジネス相談会。専門家メンタリングとICT活用講座をセットで提供します。'
-          }
-        ]
-      },
-      '益田市昭和町エリア': {
-        kids: [
-          {
-            name: '昭和ロボティクスラボ',
-            category: '科学',
-            venue: '昭和町テクノロジーセンター',
-            schedule: '毎週土曜 14:00-16:00',
-            description: 'ロボット競技会を目指す小中学生チーム。プログラミングと機械設計を実践的に学びます。'
-          },
-          {
-            name: '昭和ジュニアバレーボール',
-            category: 'スポーツ',
-            venue: '昭和町体育館',
-            schedule: '毎週火・木曜 17:30-19:00',
-            description: 'ミニバレーから始める初心者歓迎のクラブ。基礎体力づくりとチームワークを大切にしています。'
-          }
-        ],
-        adults: [
-          {
-            name: '昭和町ビジネス英語塾',
-            category: '語学',
-            venue: '昭和町学習スタジオ',
-            schedule: '毎週水曜 19:30-21:00',
-            description: '会議やメールで使える実践英語を学ぶ社会人講座。オンライン併用で通いやすいと好評です。'
-          },
-          {
-            name: '昭和シティラン&トレイル',
-            category: 'スポーツ',
-            venue: '昭和町駅前集合',
-            schedule: '毎週日曜 7:00-9:00',
-            description: '市街地と山道を走るクロストレーニングサークル。レベル別グループで安心して参加できます。'
-          },
-          {
-            name: '昭和クリエイティブスタジオナイト',
-            category: 'キャリア',
-            venue: '昭和町クリエイティブスタジオ',
-            schedule: '隔週金曜 19:00-21:30',
-            description: '動画編集とSNS配信を学ぶ実践講座。地域イベントのPR動画制作に挑戦します。'
-          }
-        ]
-      },
-      '益田市三宅町エリア': {
-        kids: [
-          {
-            name: '三宅クリエイティブラボ',
-            category: 'アート',
-            venue: '三宅町クリエイティブハブ',
-            schedule: '毎週土曜 10:00-12:00',
-            description: '動画制作・写真・デザインを学ぶ中高生向け講座。作品は地域イベントで発表します。'
-          },
-          {
-            name: '三宅イマージョン英語',
-            category: '語学',
-            venue: '三宅ラーニングスペース',
-            schedule: '毎週水曜 17:00-18:30',
-            description: '英語で理科や社会を学ぶCLILスタイルの授業。プレゼンテーション力も鍛えます。'
-          }
-        ],
-        adults: [
-          {
-            name: '三宅ナイトクリエイティブ講座',
-            category: 'キャリア',
-            venue: '三宅町クリエイティブハブ',
-            schedule: '毎週木曜 19:00-21:00',
-            description: 'デザイン思考とプレゼン術を学ぶ社会人講座。地域課題解決をテーマに実践します。'
-          },
-          {
-            name: '三宅メディテーションサークル',
-            category: 'ウェルネス',
-            venue: '三宅町ホリスティックルーム',
-            schedule: '毎週火曜 20:00-21:00',
-            description: 'マインドフルネス瞑想と呼吸法で心を整える夜のサークル。オンライン参加も可能です。'
-          },
-          {
-            name: '三宅ナイトカメラスクール',
-            category: 'アート',
-            venue: '三宅町クリエイティブハブ スタジオ',
-            schedule: '隔週水曜 19:30-21:30',
-            description: '動画撮影と編集の夜間講座。SNS向けショートムービー制作を実践的に学びます。'
-          }
-        ]
-      }
+    <script>
+    const TYPE_LABELS = {
+      elementary: '小学校',
+      middle: '中学校',
+      high: '高等学校'
     };
 
-    const typeOrder = {
+    const TYPE_ORDER = {
       elementary: 0,
       middle: 1,
       high: 2
     };
 
-    const typeKeys = Object.keys(typeOrder);
+    const SCHOOLS = [
+      {
+        name: '益田市立益田小学校',
+        type: 'elementary',
+        district: '益田地区（中心市街地）',
+        address: '島根県益田市元町6-30',
+        managingBody: '益田市教育委員会',
+        notes: '益田市中心部に位置する市立小学校です。',
+        tags: ['小学校', '公立', '市立', '中心市街地', '益田地区']
+      },
+      {
+        name: '益田市立吉田小学校',
+        type: 'elementary',
+        district: '吉田地区',
+        address: '島根県益田市乙吉町イ114',
+        managingBody: '益田市教育委員会',
+        notes: '益田市乙吉町に位置する市立小学校です。',
+        tags: ['小学校', '公立', '市立', '吉田地区']
+      },
+      {
+        name: '益田市立中西小学校',
+        type: 'elementary',
+        district: '中吉田町エリア',
+        address: '島根県益田市中吉田町37',
+        managingBody: '益田市教育委員会',
+        notes: '益田市中吉田町の農村地帯にある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '吉田地区', '中山間地域']
+      },
+      {
+        name: '益田市立高津小学校',
+        type: 'elementary',
+        district: '高津地区（沿岸部）',
+        address: '島根県益田市高津町イ2320',
+        managingBody: '益田市教育委員会',
+        notes: '益田市高津町に所在する沿岸部の市立小学校です。',
+        tags: ['小学校', '公立', '市立', '高津地区', '沿岸部']
+      },
+      {
+        name: '益田市立飯田小学校',
+        type: 'elementary',
+        district: '飯田地区',
+        address: '島根県益田市飯田町21-2',
+        managingBody: '益田市教育委員会',
+        notes: '益田市飯田町の市街地南部に位置する市立小学校です。',
+        tags: ['小学校', '公立', '市立', '益田地区']
+      },
+      {
+        name: '益田市立西益田小学校',
+        type: 'elementary',
+        district: '西益田地区',
+        address: '島根県益田市乙吉町イ331-3',
+        managingBody: '益田市教育委員会',
+        notes: '益田市乙吉町にある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '吉田地区']
+      },
+      {
+        name: '益田市立東仙道小学校',
+        type: 'elementary',
+        district: '東仙道地区',
+        address: '島根県益田市東町12-6',
+        managingBody: '益田市教育委員会',
+        notes: '益田市東町の東仙道地区に位置する市立小学校です。',
+        tags: ['小学校', '公立', '市立', '中心市街地']
+      },
+      {
+        name: '益田市立横田小学校',
+        type: 'elementary',
+        district: '横田地区',
+        address: '島根県益田市高津町イ2955',
+        managingBody: '益田市教育委員会',
+        notes: '益田市高津町横田地区にある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '高津地区']
+      },
+      {
+        name: '益田市立二条小学校',
+        type: 'elementary',
+        district: '二条地区（中山間）',
+        address: '島根県益田市二条町イ127',
+        managingBody: '益田市教育委員会',
+        notes: '益田市二条町の中山間地域にある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '二条地区', '中山間地域']
+      },
+      {
+        name: '益田市立七尾小学校',
+        type: 'elementary',
+        district: '七尾地区（沿岸部）',
+        address: '島根県益田市七尾町8',
+        managingBody: '益田市教育委員会',
+        notes: '益田市七尾町の海沿いにある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '七尾地区', '沿岸部']
+      },
+      {
+        name: '益田市立鎌手小学校',
+        type: 'elementary',
+        district: '鎌手地区（沿岸部）',
+        address: '島根県益田市鎌手町ロ77-3',
+        managingBody: '益田市教育委員会',
+        notes: '益田市鎌手町にある沿岸部の市立小学校です。',
+        tags: ['小学校', '公立', '市立', '鎌手地区', '沿岸部']
+      },
+      {
+        name: '益田市立匹見小学校',
+        type: 'elementary',
+        district: '匹見地区',
+        address: '島根県益田市匹見町匹見イ982',
+        managingBody: '益田市教育委員会',
+        notes: '益田市匹見町に位置する山間部の市立小学校です。',
+        tags: ['小学校', '公立', '市立', '匹見地区', '中山間地域']
+      },
+      {
+        name: '益田市立美都小学校',
+        type: 'elementary',
+        district: '美都地区',
+        address: '島根県益田市美都町都茂1186',
+        managingBody: '益田市教育委員会',
+        notes: '益田市美都町都茂にある旧美都町の市立小学校です。',
+        tags: ['小学校', '公立', '市立', '美都地区', '中山間地域']
+      },
+      {
+        name: '益田市立都茂小学校',
+        type: 'elementary',
+        district: '都茂地区',
+        address: '島根県益田市美都町都茂1523',
+        managingBody: '益田市教育委員会',
+        notes: '益田市美都町都茂地区にある市立小学校です。',
+        tags: ['小学校', '公立', '市立', '美都地区', '中山間地域']
+      },
+      {
+        name: '益田市立益田中学校',
+        type: 'middle',
+        district: '益田地区（中心市街地）',
+        address: '島根県益田市染羽町1-5',
+        managingBody: '益田市教育委員会',
+        notes: '益田市染羽町に所在する市立中学校です。',
+        tags: ['中学校', '公立', '市立', '中心市街地', '益田地区']
+      },
+      {
+        name: '益田市立高津中学校',
+        type: 'middle',
+        district: '高津地区',
+        address: '島根県益田市高津町イ2360',
+        managingBody: '益田市教育委員会',
+        notes: '益田市高津町にある市立中学校です。',
+        tags: ['中学校', '公立', '市立', '高津地区']
+      },
+      {
+        name: '益田市立横田中学校',
+        type: 'middle',
+        district: '横田地区',
+        address: '島根県益田市高津町イ2745',
+        managingBody: '益田市教育委員会',
+        notes: '益田市高津町横田地区にある市立中学校です。',
+        tags: ['中学校', '公立', '市立', '高津地区']
+      },
+      {
+        name: '益田市立匹見中学校',
+        type: 'middle',
+        district: '匹見地区',
+        address: '島根県益田市匹見町匹見イ1104',
+        managingBody: '益田市教育委員会',
+        notes: '益田市匹見町にある市立中学校です。',
+        tags: ['中学校', '公立', '市立', '匹見地区', '中山間地域']
+      },
+      {
+        name: '益田市立美都中学校',
+        type: 'middle',
+        district: '美都地区',
+        address: '島根県益田市美都町都茂1186-2',
+        managingBody: '益田市教育委員会',
+        notes: '益田市美都町都茂に所在する市立中学校です。',
+        tags: ['中学校', '公立', '市立', '美都地区', '中山間地域']
+      },
+      {
+        name: '益田東中学校',
+        type: 'middle',
+        district: '久城町エリア',
+        address: '島根県益田市久城町457',
+        managingBody: '学校法人益田永島学園',
+        notes: '益田東高等学校と同じ敷地にある私立中学校です。',
+        tags: ['中学校', '私立', '中高一貫', '久城町']
+      },
+      {
+        name: '島根県立益田高等学校',
+        type: 'high',
+        district: '益田地区（中心市街地）',
+        address: '島根県益田市東町20-33',
+        managingBody: '島根県教育委員会',
+        notes: '益田市東町に位置する県立高等学校です。',
+        tags: ['高等学校', '県立', '普通科', '中心市街地', '益田地区']
+      },
+      {
+        name: '島根県立益田翔陽高等学校',
+        type: 'high',
+        district: '昭和町エリア',
+        address: '島根県益田市昭和町12-1',
+        managingBody: '島根県教育委員会',
+        notes: '益田市昭和町に所在する県立高等学校です。',
+        tags: ['高等学校', '県立', '専門学科', '昭和町']
+      },
+      {
+        name: '益田東高等学校',
+        type: 'high',
+        district: '久城町エリア',
+        address: '島根県益田市久城町457',
+        managingBody: '学校法人益田永島学園',
+        notes: '益田市久城町にある私立の高等学校です。',
+        tags: ['高等学校', '私立', '中高一貫', '久城町']
+      },
+      {
+        name: '明誠高等学校',
+        type: 'high',
+        district: '三宅町エリア',
+        address: '島根県益田市三宅町7-37',
+        managingBody: '学校法人明誠高等学校',
+        notes: '益田市三宅町にある私立高等学校です。',
+        tags: ['高等学校', '私立', '三宅町']
+      }
+    ];
+
+    const typeKeys = Object.keys(TYPE_ORDER);
 
     const state = {
       types: new Set(typeKeys),
@@ -1138,7 +445,7 @@
     const clearTagsButton = document.getElementById('clear-tag-filter');
     const resultsRegion = document.querySelector('.results');
 
-    const allTags = Array.from(new Set(SCHOOLS.flatMap((school) => school.tags))).sort((a, b) =>
+    const allTags = Array.from(new Set(SCHOOLS.flatMap((school) => school.tags ?? []))).sort((a, b) =>
       a.localeCompare(b, 'ja')
     );
 
@@ -1211,96 +518,86 @@
           if (!normalizedTerm) return true;
           const keywords = [
             school.name,
-            school.area,
+            school.district,
             school.address,
+            school.managingBody,
             school.notes,
-            school.programs || '',
-            ...(school.keywords || []),
-            ...school.tags
+            ...(school.keywords ?? []),
+            ...(school.tags ?? [])
           ].join(' ');
           return normalizeText(keywords).includes(normalizedTerm);
         })
         .filter((school) => {
           if (state.tags.size === 0) return true;
-          return Array.from(state.tags).every((tag) => school.tags.includes(tag));
+          const tags = school.tags ?? [];
+          return Array.from(state.tags).some((tag) => tags.includes(tag));
         })
         .sort((a, b) => {
-          const typeDiff = typeOrder[a.type] - typeOrder[b.type];
+          const typeDiff = (TYPE_ORDER[a.type] ?? 99) - (TYPE_ORDER[b.type] ?? 99);
           if (typeDiff !== 0) return typeDiff;
           return a.name.localeCompare(b.name, 'ja');
         });
     }
 
-    function createProgramMetaItem(term, value) {
-      if (!value) return null;
-      const li = document.createElement('li');
-      const strong = document.createElement('strong');
-      strong.textContent = `${term}:`;
-      li.append(strong, document.createTextNode(` ${value}`));
-      return li;
+    function appendDetail(list, term, value) {
+      if (!value) return;
+      const dt = document.createElement('dt');
+      dt.textContent = term;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      list.append(dt, dd);
     }
 
-    function createProgramList(title, programs, audience) {
-      const section = document.createElement('section');
-      section.className = `nearby-group nearby-${audience}`;
+    function createSchoolCard(school) {
+      const article = document.createElement('article');
+      article.className = 'school-card';
+      article.setAttribute('role', 'listitem');
+      article.dataset.type = school.type;
 
-      const heading = document.createElement('h5');
-      heading.textContent = title;
-      section.appendChild(heading);
+      const header = document.createElement('header');
+      const typeLabel = document.createElement('span');
+      typeLabel.className = 'school-type';
+      typeLabel.textContent = TYPE_LABELS[school.type] ?? '学校';
+      header.appendChild(typeLabel);
 
-      if (!programs || programs.length === 0) {
-        const empty = document.createElement('p');
-        empty.className = 'nearby-empty';
-        empty.textContent = '現在登録されている講座はありません。';
-        section.appendChild(empty);
-        return section;
+      const name = document.createElement('h3');
+      name.textContent = school.name;
+      header.appendChild(name);
+
+      if (school.district) {
+        const area = document.createElement('p');
+        area.className = 'school-area';
+        area.textContent = school.district;
+        header.appendChild(area);
       }
 
-      const list = document.createElement('ul');
-      list.className = 'nearby-programs';
+      article.appendChild(header);
 
-      programs.forEach((program) => {
-        const item = document.createElement('li');
-        item.className = 'nearby-program';
+      const detail = document.createElement('dl');
+      detail.className = 'school-detail';
+      appendDetail(detail, '所在地', school.address);
+      appendDetail(detail, '設置者', school.managingBody);
+      article.appendChild(detail);
 
-        const header = document.createElement('div');
-        header.className = 'program-header';
+      if (school.notes) {
+        const notes = document.createElement('p');
+        notes.className = 'school-notes';
+        notes.textContent = school.notes;
+        article.appendChild(notes);
+      }
 
-        const category = document.createElement('span');
-        category.className = 'program-category';
-        category.textContent = program.category;
-
-        const name = document.createElement('strong');
-        name.className = 'program-name';
-        name.textContent = program.name;
-
-        header.append(category, name);
-
-        const description = document.createElement('p');
-        description.className = 'program-description';
-        description.textContent = program.description;
-
-        const meta = document.createElement('ul');
-        meta.className = 'program-meta';
-
-        const venue = createProgramMetaItem('会場', program.venue);
-        const schedule = createProgramMetaItem('スケジュール', program.schedule);
-        const contact = createProgramMetaItem('問い合わせ', program.contact);
-
-        [venue, schedule, contact].forEach((entry) => {
-          if (entry) meta.appendChild(entry);
+      if (school.tags && school.tags.length > 0) {
+        const tags = document.createElement('ul');
+        tags.className = 'school-tags';
+        school.tags.forEach((tag) => {
+          const item = document.createElement('li');
+          item.textContent = tag;
+          tags.appendChild(item);
         });
+        article.appendChild(tags);
+      }
 
-        item.append(header, description);
-        if (meta.childElementCount > 0) {
-          item.appendChild(meta);
-        }
-
-        list.appendChild(item);
-      });
-
-      section.appendChild(list);
-      return section;
+      return article;
     }
 
     function render() {
@@ -1311,45 +608,31 @@
       if (results.length === 0) {
         const empty = document.createElement('p');
         empty.className = 'empty-state';
-        empty.textContent = '該当する周辺スクール情報が見つかりませんでした。検索条件を見直してください。';
+        empty.textContent = '該当する学校情報が見つかりませんでした。検索条件を見直してください。';
         schoolList.appendChild(empty);
       } else {
         results.forEach((school) => {
-          const article = document.createElement('article');
-          article.className = 'school-card';
-          article.setAttribute('role', 'listitem');
-          article.dataset.type = school.type;
-
-          const nearbySection = document.createElement('div');
-          nearbySection.className = 'nearby-section';
-
-          const nearbyHeading = document.createElement('h4');
-          nearbyHeading.textContent = `${school.area}の周辺スクール情報`;
-          nearbySection.appendChild(nearbyHeading);
-
-          const nearbyGroups = document.createElement('div');
-          nearbyGroups.className = 'nearby-groups';
-          const nearbyData = NEARBY_PROGRAMS[school.area];
-          nearbyGroups.append(
-            createProgramList('子ども向けスクール', nearbyData && nearbyData.kids, 'kids'),
-            createProgramList('大人向けスクール', nearbyData && nearbyData.adults, 'adults')
-          );
-
-          nearbySection.appendChild(nearbyGroups);
-          article.appendChild(nearbySection);
-          schoolList.appendChild(article);
+          schoolList.appendChild(createSchoolCard(school));
         });
       }
 
-      const programCount = results.reduce((total, school) => {
-        const nearbyData = NEARBY_PROGRAMS[school.area];
-        if (!nearbyData) return total;
-        const kids = Array.isArray(nearbyData.kids) ? nearbyData.kids.length : 0;
-        const adults = Array.isArray(nearbyData.adults) ? nearbyData.adults.length : 0;
-        return total + kids + adults;
-      }, 0);
+      const typeCounts = results.reduce((acc, school) => {
+        acc[school.type] = (acc[school.type] ?? 0) + 1;
+        return acc;
+      }, {});
 
-      resultSummary.innerHTML = `<strong>${programCount}</strong> 件の周辺スクール情報を表示中<br><span class="result-breakdown">対象エリア ${results.length}件</span>`;
+      const breakdown = typeKeys
+        .map((type) => {
+          const count = typeCounts[type] ?? 0;
+          return count > 0 ? `${TYPE_LABELS[type]} ${count}校` : null;
+        })
+        .filter(Boolean)
+        .join(' / ');
+
+      resultSummary.innerHTML = `<strong>${results.length}</strong> 件のスクールを表示中${
+        breakdown ? `<br><span class="result-breakdown">${breakdown}</span>` : ''
+      }`;
+
       resultsRegion.setAttribute('aria-busy', 'false');
     }
 


### PR DESCRIPTION
## Summary
- refresh the hero copy and remove the seasonal teaser card to focus on reliable school information
- rebuild the Masuda school dataset with official names, addresses and managing bodies and switch tag filtering to OR logic
- simplify rendering to output a flat list of school cards with updated styles instead of area-based program groupings

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d4c871b7ac83248815eea93bfaaead