### PR TITLE
Update adult lesson listings and remove feature section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -535,6 +535,37 @@ img {
   color: var(--text);
 }
 
+.resource-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 16px;
+  font-size: 0.92rem;
+}
+
+.resource-list li {
+  display: grid;
+  gap: 6px;
+}
+
+.resource-list strong {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.resource-list p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.resource-source {
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
 .more {
   color: var(--primary);
   font-weight: 600;

--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
         <ul>
           <li><a href="#schools">学校別</a></li>
           <li><a href="#adults">大人向け</a></li>
-          <li><a href="#features">特集</a></li>
         </ul>
       </nav>
       <a class="cta-button" href="#schools">習い事を探す</a>
@@ -40,7 +39,7 @@
           </p>
           <div class="hero-actions">
             <a class="primary" href="#schools">習い事を検索する</a>
-            <a class="secondary" href="#features">特集を見る</a>
+            <a class="secondary" href="#adults">大人向け習い事を見る</a>
           </div>
         </div>
       </div>
@@ -92,35 +91,6 @@
       </div>
     </section>
 
-    <section id="features" class="section features">
-      <div class="container">
-        <div class="section-heading">
-          <h2>今月の特集</h2>
-          <p>人気講座や話題の先生にフォーカスしたインタビュー記事。</p>
-        </div>
-        <div class="feature-grid">
-          <article class="feature">
-            <div class="feature-label">Teacher's Voice</div>
-            <h3>益田市立高校 美術部 顧問 山本先生</h3>
-            <p>「地域の文化財を活用したアート制作で、生徒の発想力がぐっと伸びました。」</p>
-            <a class="more" href="#features">インタビューを読む</a>
-          </article>
-          <article class="feature">
-            <div class="feature-label">Hot Lesson</div>
-            <h3>島根県立大学 連携講座 デジタルクリエイティブ入門</h3>
-            <p>大学生と高校生が一緒に学ぶ人気講座。3Dモデリングや動画制作を体験できる全6回の短期集中プログラム。</p>
-            <a class="more" href="#features">日程を確認</a>
-          </article>
-          <article class="feature">
-            <div class="feature-label">Report</div>
-            <h3>石見神楽ジュニアチーム 全国大会レポート</h3>
-            <p>全国大会で披露した演目「大蛇」の舞台裏と、メンバーの熱い想いを徹底レポート。</p>
-            <a class="more" href="#features">レポートを読む</a>
-          </article>
-        </div>
-      </div>
-    </section>
-
     <section id="adults" class="section adults">
       <div class="container">
         <div class="section-heading">
@@ -130,39 +100,139 @@
         <div class="card-grid">
           <article class="card">
             <header>
-              <p class="category">キャリア</p>
-              <h3>益田市 DXリスキリング講座</h3>
+              <p class="category">スポーツ・フィットネス</p>
+              <h3>運動を楽しむ定期クラス</h3>
             </header>
-            <p>社会人のためのデジタル基礎講座。データ分析とノーコードツールを活用した業務改善を学びます。</p>
-            <ul class="meta">
-              <li><strong>期間:</strong> 5月開講 / 全8回</li>
-              <li><strong>会場:</strong> 益田産業支援センター</li>
+            <ul class="resource-list">
+              <li>
+                <strong>市民スポーツ・文化教室（益田運動公園）</strong>
+                <p>ヨガ／ピラティス／エアロビ／健康体操／フラダンス／卓球・テニスなど。昼・夜の部があり、教室名や曜日、講師一覧を公開。</p>
+                <span class="resource-source">最新情報は益田運動公園の公式ページと広報資料から確認できます。</span>
+              </li>
+              <li>
+                <strong>カーブス 益田乙吉</strong>
+                <p>女性向け30分フィットネス。予約不要のサーキットトレーニングでスキマ時間に通えます。</p>
+                <span class="resource-source">詳細はCurves公式サイト（curves.co.jp）で検索。</span>
+              </li>
+              <li>
+                <strong>ボルダリング（アンダーフォレスト益田）</strong>
+                <p>体験利用ができ、予約不要で立ち寄れるジム。Instagram投稿で最新の営業情報を発信中。</p>
+                <span class="resource-source">最新投稿はアンダーフォレスト益田のInstagramで確認。</span>
+              </li>
             </ul>
-            <span class="more" aria-label="益田市 DXリスキリング講座の詳細は各教室へお問い合わせください">詳細は各教室へ</span>
           </article>
           <article class="card">
             <header>
-              <p class="category">ウェルネス</p>
-              <h3>石見ヨガスタジオ 夜クラス</h3>
+              <p class="category">文化・教養・手しごと</p>
+              <h3>じっくり学ぶクラフト＆リベラルアーツ</h3>
             </header>
-            <p>呼吸と瞑想を取り入れたリラックスプログラム。初心者でも安心して参加できる少人数制。</p>
-            <ul class="meta">
-              <li><strong>期間:</strong> 隔週水曜日 / 19:00-20:30</li>
-              <li><strong>会場:</strong> 益田駅前スタジオ</li>
+            <ul class="resource-list">
+              <li>
+                <strong>市民スポーツ・文化教室（文化の部）</strong>
+                <p>手芸・実用書道・切り絵・ペン画など、趣味や暮らしに活かせる講座が揃っています。</p>
+                <span class="resource-source">申込要項は益田運動公園サイトで公開。</span>
+              </li>
+              <li>
+                <strong>公民館講座（各地区）</strong>
+                <p>健康・教養講座や季節の体験企画を随時募集。吉田公民館だよりなど、各地区の広報をチェック。</p>
+                <span class="resource-source">募集情報は益田市公式サイトで随時更新。</span>
+              </li>
+              <li>
+                <strong>島根県芸術文化センター「グラントワ」ワークショップ</strong>
+                <p>大人向け表現ワークショップなど、芸術体験イベントを不定期で開催。</p>
+                <span class="resource-source">最新の開催情報はshimaneiro.jpで確認。</span>
+              </li>
             </ul>
-            <span class="more" aria-label="石見ヨガスタジオ 夜クラスの詳細は各教室へお問い合わせください">詳細は各教室へ</span>
           </article>
           <article class="card">
             <header>
-              <p class="category">文化</p>
-              <h3>石見神楽保存会 社会人講座</h3>
+              <p class="category">ヨガ・ボディワーク</p>
+              <h3>心身を整えるプログラム</h3>
             </header>
-            <p>伝統芸能の舞・囃子をゼロから学べる講座。衣装着付けや歴史講座などトータルでサポート。</p>
-            <ul class="meta">
-              <li><strong>期間:</strong> 通年募集</li>
-              <li><strong>会場:</strong> 益田市立文化交流館</li>
+            <ul class="resource-list">
+              <li>
+                <strong>益田運動公園のヨガクラス</strong>
+                <p>初級・中級・リラックスなど複数クラスを曜日固定で開講。通いたいレベルに合わせて選べます。</p>
+                <span class="resource-source">教室スケジュールは益田運動公園サイトに掲載。</span>
+              </li>
+              <li>
+                <strong>ハタヨガ（studio LEAP）</strong>
+                <p>火曜夜ほかに開催。ドロップイン参加ができ、仕事帰りにも通いやすいクラス構成です。</p>
+                <span class="resource-source">予約はfreee予約ページから。</span>
+              </li>
+              <li>
+                <strong>レンタルスタジオ「studio LEAP」</strong>
+                <p>ヨガやダンスなどのレッスン会場として利用できる鏡張りスペース。自主開催も相談可能。</p>
+                <span class="resource-source">施設案内はmasudashi.com内の紹介ページを参照。</span>
+              </li>
             </ul>
-            <span class="more" aria-label="石見神楽保存会 社会人講座の詳細は各教室へお問い合わせください">詳細は各教室へ</span>
+          </article>
+          <article class="card">
+            <header>
+              <p class="category">料理・食</p>
+              <h3>旬を味わうクッキング講座</h3>
+            </header>
+            <ul class="resource-list">
+              <li>
+                <strong>市内で開かれる料理教室</strong>
+                <p>studio LEAPでの季節料理クラスや住宅メーカー会場でのイベントなど、地域主催のレッスンを随時開催。</p>
+                <span class="resource-source">最新募集は主催者のInstagram投稿などで告知。</span>
+              </li>
+            </ul>
+          </article>
+          <article class="card">
+            <header>
+              <p class="category">語学</p>
+              <h3>言葉を学ぶコミュニティ</h3>
+            </header>
+            <ul class="resource-list">
+              <li>
+                <strong>日本語ボランティア「ともがき」</strong>
+                <p>益田市人権センターで日曜午前に実施。テキスト代実費で外国人住民の日本語学習をサポート。</p>
+                <span class="resource-source">案内は益田市人権センター（sic-info.org）に掲載。</span>
+              </li>
+              <li>
+                <strong>オンライン語学レッスンの県内対応</strong>
+                <p>HH JapaNeedsなど、オンラインで益田市に対応する英会話・日本語レッスンも利用可能。</p>
+                <span class="resource-source">対応エリアは各サービスの公式サイトで確認。</span>
+              </li>
+            </ul>
+          </article>
+          <article class="card">
+            <header>
+              <p class="category">音楽・ダンス</p>
+              <h3>リズムと表現の学び</h3>
+            </header>
+            <ul class="resource-list">
+              <li>
+                <strong>益田運動公園のカルチャークラス</strong>
+                <p>フラダンスなど、音楽と身体表現を楽しむ講座を展開。</p>
+                <span class="resource-source">詳細は益田運動公園の教室案内で確認。</span>
+              </li>
+              <li>
+                <strong>studio LEAPのダンス利用</strong>
+                <p>鏡張りのスタジオスペースをダンス練習やワークショップ会場として利用可能。</p>
+                <span class="resource-source">スタジオの予約・空き状況は公式サイトで確認。</span>
+              </li>
+            </ul>
+          </article>
+          <article class="card">
+            <header>
+              <p class="category">使い方のコツ</p>
+              <h3>最新情報を逃さないために</h3>
+            </header>
+            <ul class="resource-list">
+              <li>
+                <strong>市民スポーツ・文化教室の募集時期</strong>
+                <p>募集は期ごとに行われ、広報ますだや運動公園サイトに最新PDFが掲載されます。</p>
+                <span class="resource-source">次期募集や空き状況は益田市公式サイトでチェック。</span>
+              </li>
+              <li>
+                <strong>会場型イベントの最新予定</strong>
+                <p>studio LEAPなど会場提供型のレッスンは主催者によって内容が変わるため、Instagramや予約ページで最新情報を確認しましょう。</p>
+                <span class="resource-source">freee予約ページや各主催者のSNSで更新。</span>
+              </li>
+            </ul>
           </article>
         </div>
       </div>
@@ -183,7 +253,6 @@
         <ul>
           <li><a href="#schools">学校別</a></li>
           <li><a href="#adults">大人向け</a></li>
-          <li><a href="#features">特集</a></li>
         </ul>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- remove the unused monthly feature navigation and section
- refresh the adult lesson area with new category cards and resource summaries
- add supporting styles for the new resource lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d366730c8324944a724d18d0e652