### PR TITLE
Improve mobile layout and persist tag metadata

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -922,7 +922,7 @@ img {
   }
 
   .school-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1044,6 +1044,11 @@
       article.className = 'school-card';
       article.setAttribute('role', 'listitem');
 
+      const normalizedTags = Array.isArray(school.tags)
+        ? school.tags.filter((tag) => typeof tag === 'string' && tag.trim())
+        : [];
+      article.dataset.tags = JSON.stringify(normalizedTags);
+
       const header = document.createElement('header');
       const logo = createSchoolLogo(school);
       header.appendChild(logo);
@@ -1100,10 +1105,10 @@
         article.appendChild(notes);
       }
 
-      if (school.tags && school.tags.length > 0) {
+      if (normalizedTags.length > 0) {
         const tags = document.createElement('ul');
         tags.className = 'school-tags';
-        school.tags.forEach((tag) => {
+        normalizedTags.forEach((tag) => {
           const item = document.createElement('li');
           item.textContent = tag;
           tags.appendChild(item);
@@ -1117,6 +1122,10 @@
     function render() {
       resultsRegion.setAttribute('aria-busy', 'true');
       const results = filterSchools();
+      const activeTags = Array.from(state.tags);
+      const serializedTags = JSON.stringify(activeTags);
+      schoolList.dataset.activeTags = serializedTags;
+      resultsRegion.dataset.activeTags = serializedTags;
       schoolList.replaceChildren();
 
       if (results.length === 0) {


### PR DESCRIPTION
## Summary
- adjust the small-screen school list grid so cards keep a comfortable width on phones
- normalize school tag data, persist it on each card, and expose the currently selected tags on the results container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d510ccf9408324bfafb0cdc8984df9