### PR TITLE
Adjust mobile school cards for two-column layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -866,63 +866,76 @@ img {
   }
 
   .school-card {
-    padding: 16px;
-    gap: 12px;
+    padding: 18px 16px;
+    gap: 10px;
   }
 
   .school-card h3 {
-    font-size: clamp(1.1rem, 2.4vw + 0.7rem, 1.25rem);
+    font-size: clamp(1rem, 2.2vw + 0.6rem, 1.18rem);
   }
 
   .school-card header {
-    grid-template-columns: 1fr;
+    grid-template-columns: auto 1fr;
     gap: 12px;
+    align-items: center;
   }
 
   .school-logo {
-    width: 56px;
-    height: 56px;
-    border-radius: 18px;
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
   }
 
   .school-card-heading {
-    gap: 4px;
+    gap: 6px;
   }
 
   .school-detail {
     grid-template-columns: 1fr;
-    gap: 8px;
+    gap: 6px;
   }
 
   .school-detail dt {
-    font-size: clamp(0.88rem, 1.6vw + 0.48rem, 0.96rem);
+    font-size: clamp(0.8rem, 1.4vw + 0.48rem, 0.9rem);
   }
 
   .school-detail dd {
-    margin-bottom: 6px;
-    font-size: clamp(0.92rem, 1.8vw + 0.5rem, 1.02rem);
+    margin-bottom: 4px;
+    font-size: clamp(0.85rem, 1.6vw + 0.5rem, 0.98rem);
   }
 
   .school-tags {
-    display: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 4px 0 0;
+  }
+
+  .school-tags li {
+    background: rgba(47, 77, 228, 0.08);
+    color: var(--primary);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    line-height: 1.4;
   }
 
   .school-category,
   .school-area {
-    font-size: clamp(0.88rem, 1.6vw + 0.48rem, 0.98rem);
+    font-size: clamp(0.8rem, 1.4vw + 0.48rem, 0.95rem);
   }
 
   .school-notes {
-    font-size: clamp(0.94rem, 1.8vw + 0.55rem, 1.05rem);
+    font-size: clamp(0.82rem, 1.8vw + 0.44rem, 0.98rem);
     line-height: 1.6;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
 
   .school-list {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
   }
 }


### PR DESCRIPTION
## Summary
- tune the @media (max-width: 640px) rules to support a balanced two-column layout for school cards on smartphones
- scale typography, spacing, and logo sizing for compact cards while keeping them legible
- re-enable school tags with mobile-friendly styling to surface context without stretching card height

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67cccdd248324aa69bb9df94fe491