### PR TITLE
Hide mobile school type badges and refine typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -867,7 +867,11 @@ img {
 
   .school-card {
     padding: 16px 14px;
-    gap: 8px;
+    gap: 4px;
+    aspect-ratio: 9 / 16;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 
   .school-card h3 {
@@ -875,57 +879,85 @@ img {
   }
 
   .school-card header {
-    grid-template-columns: auto 1fr;
-    gap: 12px;
+    grid-template-columns: 1fr;
+    gap: 10px;
     align-items: center;
+    text-align: center;
+  }
+
+  .school-type-group {
+    display: none;
   }
 
   .school-logo {
-    width: 48px;
-    height: 48px;
+    width: 44px;
+    height: 44px;
+    margin: 0 auto;
   }
 
   .school-card-heading {
-    gap: 6px;
+    gap: 4px;
   }
 
   .school-detail {
     grid-template-columns: 1fr;
     gap: 4px;
+    text-align: left;
   }
 
   .school-detail dt {
-    font-size: clamp(0.74rem, 1.2vw + 0.44rem, 0.86rem);
+    font-size: clamp(0.7rem, 1.1vw + 0.42rem, 0.82rem);
   }
 
   .school-detail dd {
     margin-bottom: 2px;
-    font-size: clamp(0.78rem, 1.4vw + 0.46rem, 0.9rem);
+    font-size: clamp(0.74rem, 1.3vw + 0.44rem, 0.86rem);
   }
 
   .school-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin: 2px 0 0;
+    display: none;
   }
 
-  .school-tags li {
-    background: rgba(47, 77, 228, 0.08);
-    color: var(--primary);
-    padding: 3px 8px;
-    border-radius: 999px;
-    font-size: 0.62rem;
-    line-height: 1.3;
+  .card {
+    padding: 20px;
+    gap: 12px;
+  }
+
+  .card .category {
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+  }
+
+  .card h3 {
+    font-size: clamp(0.98rem, 2.2vw + 0.58rem, 1.12rem);
+    margin-bottom: 8px;
+  }
+
+  .card p,
+  .resource-list {
+    font-size: 0.84rem;
+  }
+
+  .resource-list strong {
+    font-size: 0.92rem;
+  }
+
+  .resource-list p {
+    font-size: 0.82rem;
+    line-height: 1.6;
+  }
+
+  .resource-source {
+    font-size: 0.7rem;
   }
 
   .school-category,
   .school-area {
-    font-size: clamp(0.74rem, 1.2vw + 0.46rem, 0.9rem);
+    font-size: clamp(0.72rem, 1.1vw + 0.44rem, 0.86rem);
   }
 
   .school-notes {
-    font-size: clamp(0.76rem, 1.6vw + 0.42rem, 0.92rem);
+    font-size: clamp(0.72rem, 1.5vw + 0.4rem, 0.88rem);
     line-height: 1.5;
     display: -webkit-box;
     -webkit-line-clamp: 4;


### PR DESCRIPTION
## Summary
- remove the school type badge group from mobile cards to satisfy the smartphone layout request
- tighten spacing and shrink mobile font sizes for school details and notes to improve readability in the tall card

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d68302ecfc83248e3c8dbb75524073