### PR TITLE
Ensure mobile school cards keep text within 9:16 layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -871,7 +871,14 @@ img {
     aspect-ratio: 9 / 16;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .school-card > * {
+    flex-shrink: 0;
   }
 
   .school-card h3 {


### PR DESCRIPTION
## Summary
- allow school cards on small screens to scroll vertically so long text stays visible within the 9:16 aspect ratio
- prevent horizontal overflow and keep inner elements from shrinking while scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6870a86ec8324b6f072916e0df175