### PR TITLE
Adjust mobile tag filter layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -852,6 +852,33 @@ img {
     gap: 20px;
   }
 
+  .tag-filter {
+    gap: 12px;
+  }
+
+  .tag-filter .help-text {
+    margin-top: 4px;
+  }
+
+  .tag-list {
+    max-height: 180px;
+    overflow-y: auto;
+    padding: 10px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.95);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tag-list::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .tag-list::-webkit-scrollbar-thumb {
+    background: rgba(47, 77, 228, 0.35);
+    border-radius: 999px;
+  }
+
   .type-filter {
     padding: 14px 16px;
   }


### PR DESCRIPTION
## Summary
- tighten the spacing of the tag filter area on small screens
- add a scrollable container for the tag list on mobile to keep the search panel compact

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d690fe2b94832497b978e5fc6ab6d7