### PR TITLE
Add Google Maps buttons to school cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -478,6 +478,41 @@ img {
   font-size: 0.95rem;
 }
 
+.school-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.map-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(47, 77, 228, 0.12);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-button::before {
+  content: '';
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  mask: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M12 21s-6-5.686-6-10a6 6 0 1 1 12 0c0 4.314-6 10-6 10z"/%3E%3Ccircle cx="12" cy="11" r="2"/%3E%3C/svg%3E') no-repeat center / contain;
+  background: currentColor;
+}
+
+.map-button:hover,
+.map-button:focus {
+  background: rgba(47, 77, 228, 0.2);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(47, 77, 228, 0.16);
+}
+
 .school-notes {
   margin: 0;
   color: var(--text);

--- a/index.html
+++ b/index.html
@@ -1098,6 +1098,24 @@
       appendDetail(detail, '主催', school.managingBody);
       article.appendChild(detail);
 
+      if (school.address) {
+        const actions = document.createElement('div');
+        actions.className = 'school-actions';
+
+        const mapLink = document.createElement('a');
+        mapLink.className = 'map-button';
+        mapLink.href = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+          school.address
+        )}`;
+        mapLink.target = '_blank';
+        mapLink.rel = 'noopener';
+        mapLink.textContent = 'Googleマップで見る';
+        mapLink.setAttribute('aria-label', `${school.name}をGoogleマップで表示`);
+
+        actions.appendChild(mapLink);
+        article.appendChild(actions);
+      }
+
       if (school.notes) {
         const notes = document.createElement('p');
         notes.className = 'school-notes';


### PR DESCRIPTION
## Summary
- add a "Googleマップで見る" button to each school card so users can open the listed address directly in Google Maps
- style the new map button to align with the existing card design

## Testing
- Manual QA: Viewed index.html in browser


------
https://chatgpt.com/codex/tasks/task_e_68d7962d9abc8324b3fbf6e5b331abe6