### PR TITLE
Limit school cards to name and type with detail link

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -484,7 +484,7 @@ img {
   flex-wrap: wrap;
 }
 
-.map-button {
+.detail-button {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -497,17 +497,17 @@ img {
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.map-button::before {
+.detail-button::before {
   content: '';
   display: inline-block;
   width: 18px;
   height: 18px;
-  mask: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M12 21s-6-5.686-6-10a6 6 0 1 1 12 0c0 4.314-6 10-6 10z"/%3E%3Ccircle cx="12" cy="11" r="2"/%3E%3C/svg%3E') no-repeat center / contain;
+  mask: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M5 12h14"/%3E%3Cpath d="m13 6 6 6-6 6"/%3E%3C/svg%3E') no-repeat center / contain;
   background: currentColor;
 }
 
-.map-button:hover,
-.map-button:focus {
+.detail-button:hover,
+.detail-button:focus {
   background: rgba(47, 77, 228, 0.2);
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(47, 77, 228, 0.16);

--- a/index.html
+++ b/index.html
@@ -1031,13 +1031,18 @@
         });
     }
 
-    function appendDetail(list, term, value) {
-      if (!value) return;
-      const dt = document.createElement('dt');
-      dt.textContent = term;
-      const dd = document.createElement('dd');
-      dd.textContent = value;
-      list.append(dt, dd);
+    function getSchoolHomepage(school) {
+      const explicitUrl = [school.homepage, school.website, school.url]
+        .find((value) => typeof value === 'string' && value.trim());
+      if (explicitUrl) {
+        return explicitUrl;
+      }
+
+      const fallbackKeywords = [school.name, school.district, school.category]
+        .filter((value) => typeof value === 'string' && value.trim())
+        .join(' ');
+      const query = fallbackKeywords || school.name;
+      return `https://www.google.com/search?q=${encodeURIComponent(`${query} 公式`)}&sourceid=chrome&ie=UTF-8`;
     }
     function createSchoolCard(school) {
       const article = document.createElement('article');
@@ -1075,64 +1080,23 @@
       name.textContent = school.name;
       heading.appendChild(name);
 
-      if (school.category) {
-        const category = document.createElement('p');
-        category.className = 'school-category';
-        category.textContent = school.category;
-        heading.appendChild(category);
-      }
-
-      if (school.district) {
-        const area = document.createElement('p');
-        area.className = 'school-area';
-        area.textContent = school.district;
-        heading.appendChild(area);
-      }
-
       header.appendChild(heading);
       article.appendChild(header);
 
-      const detail = document.createElement('dl');
-      detail.className = 'school-detail';
-      appendDetail(detail, '所在地', school.address);
-      appendDetail(detail, '主催', school.managingBody);
-      article.appendChild(detail);
+      const actions = document.createElement('div');
+      actions.className = 'school-actions';
 
-      if (school.address) {
-        const actions = document.createElement('div');
-        actions.className = 'school-actions';
+      const detailLink = document.createElement('a');
+      detailLink.className = 'detail-button';
+      const homepageUrl = getSchoolHomepage(school);
+      detailLink.href = homepageUrl;
+      detailLink.target = '_blank';
+      detailLink.rel = 'noopener';
+      detailLink.textContent = '詳細を見る';
+      detailLink.setAttribute('aria-label', `${school.name}の詳細ページを開く`);
 
-        const mapLink = document.createElement('a');
-        mapLink.className = 'map-button';
-        mapLink.href = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-          school.address
-        )}`;
-        mapLink.target = '_blank';
-        mapLink.rel = 'noopener';
-        mapLink.textContent = 'Googleマップで見る';
-        mapLink.setAttribute('aria-label', `${school.name}をGoogleマップで表示`);
-
-        actions.appendChild(mapLink);
-        article.appendChild(actions);
-      }
-
-      if (school.notes) {
-        const notes = document.createElement('p');
-        notes.className = 'school-notes';
-        notes.textContent = school.notes;
-        article.appendChild(notes);
-      }
-
-      if (normalizedTags.length > 0) {
-        const tags = document.createElement('ul');
-        tags.className = 'school-tags';
-        normalizedTags.forEach((tag) => {
-          const item = document.createElement('li');
-          item.textContent = tag;
-          tags.appendChild(item);
-        });
-        article.appendChild(tags);
-      }
+      actions.appendChild(detailLink);
+      article.appendChild(actions);
 
       return article;
     }


### PR DESCRIPTION
## Summary
- reduce school cards to show the school name with its target types only
- add a detail button that opens each school's homepage (with a search fallback)
- style the new detail button to keep the existing card appearance

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dbb3ddbdb0832496d986048f5ca787